### PR TITLE
add read_only_mode

### DIFF
--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -258,7 +258,6 @@ namespace chainbase {
          database& operator=(database&&) = default;
          bool is_read_only() const { return _read_only; }
          void flush();
-         void set_require_locking( bool enable_require_locking );
 
          struct session {
             public:

--- a/src/chainbase.cpp
+++ b/src/chainbase.cpp
@@ -23,11 +23,6 @@ namespace chainbase {
       _index_map.clear();
    }
 
-   void database::set_require_locking( bool enable_require_locking )
-   {
-      ;
-   }
-
    void database::undo()
    {
       if ( _read_only_mode )


### PR DESCRIPTION
This is the first PR for the read only transaction feature. `Chainbase` submodule in `Leap` will be updated after this PR is merged.

Uses of the new methods `set_read_only_mode` and `unset_read_only_mode` will be in the upcoming `Leap` PR.