### PR TITLE
fix boost include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,8 @@ file(GLOB HEADERS "include/chainbase/*.hpp")
 add_library( chainbase src/chainbase.cpp src/pinnable_mapped_file.cpp ${HEADERS} )
 target_link_libraries( chainbase ${PLATFORM_LIBRARIES} Boost::boost)
 target_include_directories( chainbase PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
 if(WIN32)
    target_link_libraries( chainbase ws2_32 mswsock )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,11 +64,10 @@ endif()
 
 file(GLOB HEADERS "include/chainbase/*.hpp")
 add_library( chainbase src/chainbase.cpp src/pinnable_mapped_file.cpp ${HEADERS} )
-target_link_libraries( chainbase ${PLATFORM_LIBRARIES} )
+target_link_libraries( chainbase ${PLATFORM_LIBRARIES} Boost::boost)
 target_include_directories( chainbase PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  ${Boost_INCLUDE_DIRS})
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 if(WIN32)
    target_link_libraries( chainbase ws2_32 mswsock )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ IF( WIN32 )
   set(BOOST_ALL_DYN_LINK OFF) # force dynamic linking for all libraries
 ENDIF(WIN32)
 
-FIND_PACKAGE(Boost 1.57 REQUIRED COMPONENTS unit_test_framework)
+FIND_PACKAGE(Boost 1.67 REQUIRED COMPONENTS unit_test_framework)
 
 SET(PLATFORM_LIBRARIES)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,10 @@ endif()
 file(GLOB HEADERS "include/chainbase/*.hpp")
 add_library( chainbase src/chainbase.cpp src/pinnable_mapped_file.cpp ${HEADERS} )
 target_link_libraries( chainbase ${PLATFORM_LIBRARIES} )
-target_include_directories( chainbase PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+target_include_directories( chainbase PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  ${Boost_INCLUDE_DIRS})
 
 if(WIN32)
    target_link_libraries( chainbase ws2_32 mswsock )


### PR DESCRIPTION
This PR 
- fixes  the bug introduced by PR #6 where the compiler cannot find the boost headers when boost is not installed in the system path.
- follows [modern cmake practice](https://cliutils.gitlab.io/modern-cmake/chapters/basics/functions.html) by using generator-expressions to support package installation.