### PR TITLE
Fix comparison of different signedness warning

### DIFF
--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -162,7 +162,7 @@ namespace chainbase {
          virtual uint32_t type_id()const  = 0;
          virtual uint64_t row_count()const = 0;
          virtual const std::string& type_name()const = 0;
-         virtual std::pair<int64_t, int64_t> undo_stack_revision_range()const = 0;
+         virtual std::pair<uint64_t, uint64_t> undo_stack_revision_range()const = 0;
 
          virtual void remove_object( int64_t id ) = 0;
 
@@ -189,7 +189,7 @@ namespace chainbase {
          virtual uint32_t type_id()const override { return BaseIndex::value_type::type_id; }
          virtual uint64_t row_count()const override { return _base.indices().size(); }
          virtual const std::string& type_name() const override { return BaseIndex_name; }
-         virtual std::pair<int64_t, int64_t> undo_stack_revision_range()const override { return _base.undo_stack_revision_range(); }
+         virtual std::pair<uint64_t, uint64_t> undo_stack_revision_range()const override { return _base.undo_stack_revision_range(); }
 
          virtual void     remove_object( int64_t id ) override { return _base.remove_object( id ); }
       private:

--- a/include/chainbase/undo_index.hpp
+++ b/include/chainbase/undo_index.hpp
@@ -521,7 +521,7 @@ namespace chainbase {
          if( _undo_stack.size() != 0 )
             BOOST_THROW_EXCEPTION( std::logic_error("cannot set revision while there is an existing undo stack") );
 
-         if( revision > std::numeric_limits<int64_t>::max() )
+         if( revision > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) )
             BOOST_THROW_EXCEPTION( std::logic_error("revision to set is too high") );
 
          if( static_cast<int64_t>(revision) < _revision )

--- a/include/chainbase/undo_index.hpp
+++ b/include/chainbase/undo_index.hpp
@@ -511,7 +511,7 @@ namespace chainbase {
          bool _apply = true;
       };
 
-      int64_t revision() const { return _revision; }
+      uint64_t revision() const { return _revision; }
 
       session start_undo_session( bool enabled ) {
          return session{*this, enabled};
@@ -521,28 +521,25 @@ namespace chainbase {
          if( _undo_stack.size() != 0 )
             BOOST_THROW_EXCEPTION( std::logic_error("cannot set revision while there is an existing undo stack") );
 
-         if( revision > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) )
-            BOOST_THROW_EXCEPTION( std::logic_error("revision to set is too high") );
-
-         if( static_cast<int64_t>(revision) < _revision )
+         if( revision < _revision )
             BOOST_THROW_EXCEPTION( std::logic_error("revision cannot decrease") );
 
-         _revision = static_cast<int64_t>(revision);
+         _revision = revision;
       }
 
-      std::pair<int64_t, int64_t> undo_stack_revision_range() const {
+      std::pair<uint64_t, uint64_t> undo_stack_revision_range() const {
          return { _revision - _undo_stack.size(), _revision };
       }
 
       /**
        * Discards all undo history prior to revision
        */
-      void commit( int64_t revision ) noexcept {
+      void commit( uint64_t revision ) noexcept {
          revision = std::min(revision, _revision);
          if (revision == _revision) {
             dispose_undo();
             _undo_stack.clear();
-         } else if( static_cast<uint64_t>(_revision - revision) < _undo_stack.size() ) {
+         } else if( _revision - revision < _undo_stack.size() ) {
             auto iter = _undo_stack.begin() + (_undo_stack.size() - (_revision - revision));
             dispose(get_old_values_end(*iter), get_removed_values_end(*iter));
             _undo_stack.erase(_undo_stack.begin(), iter);
@@ -897,7 +894,7 @@ namespace chainbase {
       rebind_alloc_t<Allocator, node> _allocator;
       rebind_alloc_t<Allocator, old_node> _old_values_allocator;
       id_type _next_id = 0;
-      int64_t _revision = 0;
+      uint64_t _revision = 0;
       uint64_t _monotonic_revision = 0;
       uint32_t                        _size_of_value_type = sizeof(node);
       uint32_t                        _size_of_this = sizeof(undo_index);


### PR DESCRIPTION
Leap on Main branch compiles very clean on Ubuntu 20.02, with only two types and 27 instances of warnings. 26 of them are

```
/home/lh/work/leap-main/libraries/chainbase/include/chainbase/undo_index.hpp:524:23:    warning: comparison of integer expressions of different signedness: ‘uint64_t’ {aka ‘long unsigned int’} and ‘long int’ [-Wsign-compare]
  524 |          if( revision > std::numeric_limits<int64_t>::max() )
      |              ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

It is unclear why  `_revision` was defined as `int64_t` not `uint64_t` originally. Instead of changing `_revision`'s type which might introduce other unforeseen problems, a safer way is to change  `if( revision > std::numeric_limits<int64_t>::max() )` to `if( revision > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) )`. This static_cast is valid, since `std::numeric_limits<int64_t>::max()) `is a positive fixed constant.


============= Final solution ===============

During the review, @heifner suggested the right solution is to change `_revision` to `uint64_t` as original assumption about `int64_t` no longer holds. The final solution is changing `_revision` to `uint64_t`

Resolves https://github.com/AntelopeIO/chainbase/pull/10