### PR TITLE
add const to operator== & operator!= to avoid c++20 warning

### DIFF
--- a/include/chainbase/environment.hpp
+++ b/include/chainbase/environment.hpp
@@ -56,10 +56,10 @@ struct environment  {
    uint8_t reserved[512] = {};
    char compiler[256] = {};
 
-   bool operator==(const environment& other) {
+   bool operator==(const environment& other) const {
       return !memcmp(this, &other, sizeof(environment));
    } 
-   bool operator!=(const environment& other) {
+   bool operator!=(const environment& other) const {
       return !(*this == other);
    }
 } __attribute__ ((packed));


### PR DESCRIPTION
These need to be const to avoid a warning about c++20 ambiguity