### PR TITLE
[update] reduce chainbase memory usage

### DIFF
--- a/include/chainbase/undo_index.hpp
+++ b/include/chainbase/undo_index.hpp
@@ -59,13 +59,13 @@ namespace chainbase {
    };
 
    // --------------------------------------------------------------------------------------
-   // Because the pointers are always aligned to an 8 byte boundary
-   // (so the 3 least significant bits are always 0), we store pointer offsets
-   // shifted by three bits, extending our maximum memory support from 2^41 = 2TB
-   // to 2^44 = 16TB.
+   // Because the pointers are always aligned to an 4 byte boundary
+   // (so the 2 least significant bits are always 0), we store pointer offsets
+   // shifted by two bits, extending our maximum memory support from 2^41 = 2TB
+   // to 2^43 = 8TB.
    // A concern could be that `1` is a special value meaning `nullptr`. However we could not
-   // get an offset of 8, since `sizeof(offset_node_base) == 16`, so we could not have
-   // difference between two `node_ptr` less than 16.
+   // get an offset of 4, since `sizeof(offset_node_base) == 16`, so we could not have
+   // difference between two different `node_ptr` be less than 16.
    // --------------------------------------------------------------------------------------
    template<class Tag>
    struct offset_node_traits {
@@ -75,38 +75,38 @@ namespace chainbase {
       using color = int;
       static node_ptr get_parent(const_node_ptr n) {
          if(n->_parent == 1) return nullptr;
-         return (node_ptr)((char*)n + (n->_parent << 3));
+         return (node_ptr)((char*)n + (n->_parent << 2));
       }
       static void set_parent(node_ptr n, node_ptr parent) {
          if(parent == nullptr) n->_parent = 1;
          else {
             int64_t offset = (char*)parent - (char*)n;
-            assert((offset & 0x7) == 0);
-            n->_parent = offset >> 3;
+            assert((offset & 0x3) == 0);
+            n->_parent = offset >> 2;
          }
       }
       static node_ptr get_left(const_node_ptr n) {
          if(n->_left == 1) return nullptr;
-         return (node_ptr)((char*)n + (n->_left << 3));
+         return (node_ptr)((char*)n + (n->_left << 2));
       }
       static void set_left(node_ptr n, node_ptr left) {
          if(left == nullptr) n->_left = 1;
          else {
             int64_t offset = (char*)left - (char*)n;
-            assert((offset & 0x7) == 0);
-            n->_left = offset >> 3;
+            assert((offset & 0x3) == 0);
+            n->_left = offset >> 2;
          }
       }
       static node_ptr get_right(const_node_ptr n) {
          if(n->_right == 1) return nullptr;
-         return (node_ptr)((char*)n + (n->_right << 3));
+         return (node_ptr)((char*)n + (n->_right << 2));
       }
       static void set_right(node_ptr n, node_ptr right) {
          if(right == nullptr) n->_right = 1;
          else {
             int64_t offset = (char*)right - (char*)n;
-            assert((offset & 0x7) == 0);
-            n->_right = offset >> 3;
+            assert((offset & 0x3) == 0);
+            n->_right = offset >> 2;
          }
       }
       // red-black tree

--- a/include/chainbase/undo_index.hpp
+++ b/include/chainbase/undo_index.hpp
@@ -53,11 +53,20 @@ namespace chainbase {
       offset_node_base(const offset_node_base&) {}
       constexpr offset_node_base& operator=(const offset_node_base&) { return *this; }
       int64_t _parent:42;
-      int64_t _left:42;
-      int64_t _right:42;
-      int64_t _color:2;
+      int64_t _left  :42;
+      int64_t _right :42;
+      int64_t _color :2;
    };
 
+   // --------------------------------------------------------------------------------------
+   // Because the pointers are always aligned to an 8 byte boundary
+   // (so the 3 least significant bits are always 0), we store pointer offsets
+   // shifted by three bits, extending our maximum memory support from 2^41 = 2TB
+   // to 2^44 = 16TB.
+   // A concern could be that `1` is a special value meaning `nullptr`. However we could not
+   // get an offset of 8, since `sizeof(offset_node_base) == 16`, so we could not have
+   // difference between two `node_ptr` less than 16.
+   // --------------------------------------------------------------------------------------
    template<class Tag>
    struct offset_node_traits {
       using node = offset_node_base<Tag>;
@@ -66,38 +75,38 @@ namespace chainbase {
       using color = int;
       static node_ptr get_parent(const_node_ptr n) {
          if(n->_parent == 1) return nullptr;
-         return (node_ptr)((char*)n + (n->_parent << 2));
+         return (node_ptr)((char*)n + (n->_parent << 3));
       }
       static void set_parent(node_ptr n, node_ptr parent) {
          if(parent == nullptr) n->_parent = 1;
          else {
             int64_t offset = (char*)parent - (char*)n;
-            assert((offset & 0x3) == 0);
-            n->_parent = offset >> 2;
+            assert((offset & 0x7) == 0);
+            n->_parent = offset >> 3;
          }
       }
       static node_ptr get_left(const_node_ptr n) {
          if(n->_left == 1) return nullptr;
-         return (node_ptr)((char*)n + (n->_left << 2));
+         return (node_ptr)((char*)n + (n->_left << 3));
       }
       static void set_left(node_ptr n, node_ptr left) {
          if(left == nullptr) n->_left = 1;
          else {
             int64_t offset = (char*)left - (char*)n;
-            assert((offset & 0x3) == 0);
-            n->_left = offset >> 2;
+            assert((offset & 0x7) == 0);
+            n->_left = offset >> 3;
          }
       }
       static node_ptr get_right(const_node_ptr n) {
          if(n->_right == 1) return nullptr;
-         return (node_ptr)((char*)n + (n->_right << 2));
+         return (node_ptr)((char*)n + (n->_right << 3));
       }
       static void set_right(node_ptr n, node_ptr right) {
          if(right == nullptr) n->_right = 1;
          else {
             int64_t offset = (char*)right - (char*)n;
-            assert((offset & 0x3) == 0);
-            n->_right = offset >> 2;
+            assert((offset & 0x7) == 0);
+            n->_right = offset >> 3;
          }
       }
       // red-black tree

--- a/include/chainbase/undo_index.hpp
+++ b/include/chainbase/undo_index.hpp
@@ -66,27 +66,39 @@ namespace chainbase {
       using color = int;
       static node_ptr get_parent(const_node_ptr n) {
          if(n->_parent == 1) return nullptr;
-         return (node_ptr)((char*)n + n->_parent);
+         return (node_ptr)((char*)n + (n->_parent << 2));
       }
       static void set_parent(node_ptr n, node_ptr parent) {
          if(parent == nullptr) n->_parent = 1;
-         else n->_parent = (char*)parent - (char*)n;
+         else {
+            int64_t offset = (char*)parent - (char*)n;
+            assert((offset & 0x3) == 0);
+            n->_parent = offset >> 2;
+         }
       }
       static node_ptr get_left(const_node_ptr n) {
          if(n->_left == 1) return nullptr;
-         return (node_ptr)((char*)n + n->_left);
+         return (node_ptr)((char*)n + (n->_left << 2));
       }
       static void set_left(node_ptr n, node_ptr left) {
          if(left == nullptr) n->_left = 1;
-         else n->_left = (char*)left - (char*)n;
+         else {
+            int64_t offset = (char*)left - (char*)n;
+            assert((offset & 0x3) == 0);
+            n->_left = offset >> 2;
+         }
       }
       static node_ptr get_right(const_node_ptr n) {
          if(n->_right == 1) return nullptr;
-         return (node_ptr)((char*)n + n->_right);
+         return (node_ptr)((char*)n + (n->_right << 2));
       }
       static void set_right(node_ptr n, node_ptr right) {
          if(right == nullptr) n->_right = 1;
-         else n->_right = (char*)right - (char*)n;
+         else {
+            int64_t offset = (char*)right - (char*)n;
+            assert((offset & 0x3) == 0);
+            n->_right = offset >> 2;
+         }
       }
       // red-black tree
       static color get_color(node_ptr n) {

--- a/include/chainbase/undo_index.hpp
+++ b/include/chainbase/undo_index.hpp
@@ -23,7 +23,7 @@ namespace chainbase {
    template<typename F>
    struct scope_exit {
     public:
-      scope_exit(F&& f) : _f(f) {}
+      [[nodiscard]] scope_exit(F&& f) : _f(std::move(f)) {}
       scope_exit(const scope_exit&) = delete;
       scope_exit& operator=(const scope_exit&) = delete;
       ~scope_exit() { if(!_canceled) _f(); }
@@ -47,18 +47,16 @@ namespace chainbase {
       T _item;
    };
 
-#pragma pack(push, 2)
    template<class Tag>
-   struct offset_node_base {
+   struct __attribute__((packed, aligned(4))) offset_node_base {
       offset_node_base() = default;
       offset_node_base(const offset_node_base&) {}
       constexpr offset_node_base& operator=(const offset_node_base&) { return *this; }
       int64_t _parent:42;
       int64_t _left:42;
       int64_t _right:42;
-      int16_t _color:2;
+      int64_t _color:2;
    };
-#pragma pack(pop)
 
    template<class Tag>
    struct offset_node_traits {

--- a/test/undo_index.cpp
+++ b/test/undo_index.cpp
@@ -1,5 +1,5 @@
-#include "chainbase/chainbase.hpp"
 #include <chainbase/undo_index.hpp>
+#include <chainbase/chainbase.hpp>
 
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>

--- a/test/undo_index.cpp
+++ b/test/undo_index.cpp
@@ -1,3 +1,4 @@
+#include "chainbase/chainbase.hpp"
 #include <chainbase/undo_index.hpp>
 
 #include <boost/multi_index/member.hpp>
@@ -50,18 +51,27 @@ struct throwing_copy {
    throwing_copy& operator=(throwing_copy&&) noexcept = default;
 };
 
+namespace bip = boost::interprocess;
+namespace bfs = boost::filesystem;
+
 template<typename T>
-struct test_allocator : std::allocator<T> {
-   test_allocator() = default;
+using test_allocator_base = chainbase::chainbase_node_allocator<T, chainbase::pinnable_mapped_file::segment_manager>;
+
+template<typename T>
+class test_allocator : public test_allocator_base<T> {
+public:
+   using base = test_allocator_base<T>;
+   test_allocator(chainbase::pinnable_mapped_file::segment_manager *mgr) : base(mgr) {}
    template<typename U>
-   test_allocator(const test_allocator<U>&) {}
+   test_allocator(const test_allocator<U>& o) : base(o.get_segment_manager()) {}
    template<typename U>
    struct rebind { using other = test_allocator<U>; };
-   T* allocate(std::size_t count) {
+   typename base::pointer allocate(std::size_t count) {
       throw_point<std::bad_alloc>();
-      return std::allocator<T>::allocate(count);
+      return base::allocate(count);
    }
 };
+   
 
 template<typename F>
 struct scope_fail {
@@ -75,7 +85,8 @@ struct scope_fail {
 
 struct basic_element_t {
    template<typename C, typename A>
-   basic_element_t(C&& c, const std::allocator<A>&) { c(*this); }
+   basic_element_t(C&& c, A&&) { c(*this); }
+   
    uint64_t id;
    throwing_copy dummy;
 };
@@ -94,30 +105,41 @@ using key = typename key_impl<decltype(Fn)>::template fn<Fn>;
 BOOST_AUTO_TEST_SUITE(undo_index_tests)
 
 #define EXCEPTION_TEST_CASE(name)                               \
-   void name##impl();                                         \
+   void name##impl();                                           \
    BOOST_AUTO_TEST_CASE(name) { test_exceptions(&name##impl); } \
    void name##impl ()
 
 EXCEPTION_TEST_CASE(test_simple) {
-   chainbase::undo_index<basic_element_t, test_allocator<basic_element_t>, boost::multi_index::ordered_unique<key<&basic_element_t::id>>> i0;
-   i0.emplace([](basic_element_t& elem) {});
-   const basic_element_t* element = i0.find(0);
-   BOOST_TEST((element != nullptr && element->id == 0));
-   const basic_element_t* e1 = i0.find(1);
-   BOOST_TEST(e1 == nullptr);
-   i0.emplace([](basic_element_t& elem) {});
-   const basic_element_t* e2 = i0.find(1);
-   BOOST_TEST((e2 != nullptr && e2->id == 1));
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<basic_element_t, test_allocator<basic_element_t>,
+                            boost::multi_index::ordered_unique<key<&basic_element_t::id>>> i0(alloc);
+      i0.emplace([](basic_element_t& elem) {});
+      const basic_element_t* element = i0.find(0);
+      BOOST_TEST((element != nullptr && element->id == 0));
+      const basic_element_t* e1 = i0.find(1);
+      BOOST_TEST(e1 == nullptr);
+      i0.emplace([](basic_element_t& elem) {});
+      const basic_element_t* e2 = i0.find(1);
+      BOOST_TEST((e2 != nullptr && e2->id == 1));
 
-   i0.modify(*element, [](basic_element_t& elem) {});
-   i0.remove(*element);
-   element = i0.find(0);
-   BOOST_TEST(element == nullptr);
+      i0.modify(*element, [](basic_element_t& elem) {});
+      i0.remove(*element);
+      element = i0.find(0);
+      BOOST_TEST(element == nullptr);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
+   }
+   bfs::remove_all( temp );
 }
 
 struct test_element_t {
    template<typename C, typename A>
-   test_element_t(C&& c, const std::allocator<A>&) { c(*this); }
+   test_element_t(C&& c, A&&) { c(*this);  }
+   
    uint64_t id;
    int secondary;
    throwing_copy dummy;
@@ -146,351 +168,530 @@ auto capture_state(const C& index) {
 }
 
 EXCEPTION_TEST_CASE(test_insert_undo) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary> > > i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session = i0.start_undo_session(true);
-   i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-   BOOST_TEST(i0.find(1)->secondary == 12);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary> > > i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session = i0.start_undo_session(true);
+         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0.find(1)->secondary == 12);
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0.find(1) == nullptr);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   BOOST_TEST(i0.find(1) == nullptr);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_squash) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary> > > i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session0 = i0.start_undo_session(true);
-   auto session1 = i0.start_undo_session(true);
-   i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-   BOOST_TEST(i0.find(1)->secondary == 12);
-   session1.squash();
-   BOOST_TEST(i0.find(1)->secondary == 12);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary> > > i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session0 = i0.start_undo_session(true);
+         auto session1 = i0.start_undo_session(true);
+         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0.find(1)->secondary == 12);
+         session1.squash();
+         BOOST_TEST(i0.find(1)->secondary == 12);
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0.find(1) == nullptr);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   BOOST_TEST(i0.find(1) == nullptr);
-}
+   bfs::remove_all( temp );}
 
 EXCEPTION_TEST_CASE(test_insert_push) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary> > > i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session = i0.start_undo_session(true);
-   i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-   BOOST_TEST(i0.find(1)->secondary == 12);
-   session.push();
-   i0.commit(i0.revision());
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary> > > i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session = i0.start_undo_session(true);
+         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0.find(1)->secondary == 12);
+         session.push();
+         i0.commit(i0.revision());
+      }
+      BOOST_TEST(!i0.has_undo_session());
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0.find(1)->secondary == 12);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(!i0.has_undo_session());
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   BOOST_TEST(i0.find(1)->secondary == 12);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_undo) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session = i0.start_undo_session(true);
-   i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-   BOOST_TEST(i0.find(0)->secondary == 18);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session = i0.start_undo_session(true);
+         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0.find(0)->secondary == 18);
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_squash) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session0 = i0.start_undo_session(true);
-   auto session1 = i0.start_undo_session(true);
-   i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-   BOOST_TEST(i0.find(0)->secondary == 18);
-   session1.squash();
-   BOOST_TEST(i0.find(0)->secondary == 18);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session0 = i0.start_undo_session(true);
+         auto session1 = i0.start_undo_session(true);
+         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0.find(0)->secondary == 18);
+         session1.squash();
+         BOOST_TEST(i0.find(0)->secondary == 18);
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_push) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session = i0.start_undo_session(true);
-   i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-   BOOST_TEST(i0.find(0)->secondary == 18);
-   session.push();
-   i0.commit(i0.revision());
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session = i0.start_undo_session(true);
+         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0.find(0)->secondary == 18);
+         session.push();
+         i0.commit(i0.revision());
+      }
+      BOOST_TEST(!i0.has_undo_session());
+      BOOST_TEST(i0.find(0)->secondary == 18);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(!i0.has_undo_session());
-   BOOST_TEST(i0.find(0)->secondary == 18);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_remove_undo) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session = i0.start_undo_session(true);
-   i0.remove(*i0.find(0));
-   BOOST_TEST(i0.find(0) == nullptr);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session = i0.start_undo_session(true);
+         i0.remove(*i0.find(0));
+         BOOST_TEST(i0.find(0) == nullptr);
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_remove_squash) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session0 = i0.start_undo_session(true);
-   auto session1 = i0.start_undo_session(true);
-   i0.remove(*i0.find(0));
-   BOOST_TEST(i0.find(0) == nullptr);
-   session1.squash();
-   BOOST_TEST(i0.find(0) == nullptr);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session0 = i0.start_undo_session(true);
+         auto session1 = i0.start_undo_session(true);
+         i0.remove(*i0.find(0));
+         BOOST_TEST(i0.find(0) == nullptr);
+         session1.squash();
+         BOOST_TEST(i0.find(0) == nullptr);
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_remove_push) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session = i0.start_undo_session(true);
-   i0.remove(*i0.find(0));
-   BOOST_TEST(i0.find(0) == nullptr);
-   session.push();
-   i0.commit(i0.revision());
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session = i0.start_undo_session(true);
+         i0.remove(*i0.find(0));
+         BOOST_TEST(i0.find(0) == nullptr);
+         session.push();
+         i0.commit(i0.revision());
+      }
+      BOOST_TEST(!i0.has_undo_session());
+      BOOST_TEST(i0.find(0) == nullptr);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(!i0.has_undo_session());
-   BOOST_TEST(i0.find(0) == nullptr);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_modify) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-   BOOST_TEST(i0.find(1)->secondary == 12);
-   i0.modify(*i0.find(1), [](test_element_t& elem) { elem.secondary = 24; });
-   BOOST_TEST(i0.find(1)->secondary == 24);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
+      BOOST_TEST(i0.find(1)->secondary == 12);
+      i0.modify(*i0.find(1), [](test_element_t& elem) { elem.secondary = 24; });
+      BOOST_TEST(i0.find(1)->secondary == 24);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
+   }
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_modify_undo) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session = i0.start_undo_session(true);
-   i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-   BOOST_TEST(i0.find(1)->secondary == 12);
-   i0.modify(*i0.find(1), [](test_element_t& elem) { elem.secondary = 24; });
-   BOOST_TEST(i0.find(1)->secondary == 24);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session = i0.start_undo_session(true);
+         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0.find(1)->secondary == 12);
+         i0.modify(*i0.find(1), [](test_element_t& elem) { elem.secondary = 24; });
+         BOOST_TEST(i0.find(1)->secondary == 24);
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0.find(1) == nullptr);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   BOOST_TEST(i0.find(1) == nullptr);
+   bfs::remove_all( temp );
 }
 
 
 EXCEPTION_TEST_CASE(test_insert_modify_squash) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session1 = i0.start_undo_session(true);
-   i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-   BOOST_TEST(i0.find(1)->secondary == 12);
-   auto session2 = i0.start_undo_session(true);
-   i0.modify(*i0.find(1), [](test_element_t& elem) { elem.secondary = 24; });
-   BOOST_TEST(i0.find(1)->secondary == 24);
-   session2.squash();
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session1 = i0.start_undo_session(true);
+         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0.find(1)->secondary == 12);
+         auto session2 = i0.start_undo_session(true);
+         i0.modify(*i0.find(1), [](test_element_t& elem) { elem.secondary = 24; });
+         BOOST_TEST(i0.find(1)->secondary == 24);
+         session2.squash();
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0.find(1) == nullptr);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   BOOST_TEST(i0.find(1) == nullptr);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_remove_undo) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session = i0.start_undo_session(true);
-   i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-   BOOST_TEST(i0.find(1)->secondary == 12);
-   i0.remove(*i0.find(1));
-   BOOST_TEST(i0.find(1) == nullptr);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session = i0.start_undo_session(true);
+         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0.find(1)->secondary == 12);
+         i0.remove(*i0.find(1));
+         BOOST_TEST(i0.find(1) == nullptr);
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0.find(1) == nullptr);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   BOOST_TEST(i0.find(1) == nullptr);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_remove_squash) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session1 = i0.start_undo_session(true);
-   i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-   BOOST_TEST(i0.find(1)->secondary == 12);
-   auto session2 = i0.start_undo_session(true);
-   i0.remove(*i0.find(1));
-   BOOST_TEST(i0.find(1) == nullptr);
-   session2.squash();
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session1 = i0.start_undo_session(true);
+         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0.find(1)->secondary == 12);
+         auto session2 = i0.start_undo_session(true);
+         i0.remove(*i0.find(1));
+         BOOST_TEST(i0.find(1) == nullptr);
+         session2.squash();
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0.find(1) == nullptr);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   BOOST_TEST(i0.find(1) == nullptr);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_modify_undo) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session = i0.start_undo_session(true);
-   i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-   BOOST_TEST(i0.find(0)->secondary == 18);
-   i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 24; });
-   BOOST_TEST(i0.find(0)->secondary == 24);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session = i0.start_undo_session(true);
+         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0.find(0)->secondary == 18);
+         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 24; });
+         BOOST_TEST(i0.find(0)->secondary == 24);
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_modify_squash) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session1 = i0.start_undo_session(true);
-   i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-   BOOST_TEST(i0.find(0)->secondary == 18);
-   auto session2 = i0.start_undo_session(true);
-   i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 24; });
-   BOOST_TEST(i0.find(0)->secondary == 24);
-   session2.squash();
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session1 = i0.start_undo_session(true);
+         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0.find(0)->secondary == 18);
+         auto session2 = i0.start_undo_session(true);
+         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 24; });
+         BOOST_TEST(i0.find(0)->secondary == 24);
+         session2.squash();
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_remove_undo) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session = i0.start_undo_session(true);
-   i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-   BOOST_TEST(i0.find(0)->secondary == 18);
-   i0.remove(*i0.find(0));
-   BOOST_TEST(i0.find(0) == nullptr);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session = i0.start_undo_session(true);
+         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0.find(0)->secondary == 18);
+         i0.remove(*i0.find(0));
+         BOOST_TEST(i0.find(0) == nullptr);
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_remove_squash) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   auto undo_checker = capture_state(i0);
-   auto session1 = i0.start_undo_session(true);
-   i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-   BOOST_TEST(i0.find(0)->secondary == 18);
-   auto session2 = i0.start_undo_session(true);
-   i0.remove(*i0.find(0));
-   BOOST_TEST(i0.find(0) == nullptr);
-   session2.squash();
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         auto undo_checker = capture_state(i0);
+         auto session1 = i0.start_undo_session(true);
+         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0.find(0)->secondary == 18);
+         auto session2 = i0.start_undo_session(true);
+         i0.remove(*i0.find(0));
+         BOOST_TEST(i0.find(0) == nullptr);
+         session2.squash();
+      }
+      BOOST_TEST(i0.find(0)->secondary == 42);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->secondary == 42);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_squash_one) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   {
-   i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-   BOOST_TEST(i0.find(0)->secondary == 18);
-   auto session2 = i0.start_undo_session(true);
-   i0.remove(*i0.find(0));
-   BOOST_TEST(i0.find(0) == nullptr);
-   session2.squash();
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      {
+         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0.find(0)->secondary == 18);
+         auto session2 = i0.start_undo_session(true);
+         i0.remove(*i0.find(0));
+         BOOST_TEST(i0.find(0) == nullptr);
+         session2.squash();
+      }
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_non_unique) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.find(0)->secondary == 42);
-   BOOST_CHECK_THROW(i0.emplace([](test_element_t& elem) { elem.secondary = 42; }),  std::exception);
-   BOOST_TEST(i0.find(0)->secondary == 42);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_CHECK_THROW(i0.emplace([](test_element_t& elem) { elem.secondary = 42; }),  std::exception);
+      BOOST_TEST(i0.find(0)->secondary == 42);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
+   }
+   bfs::remove_all( temp );
 }
 
 struct conflict_element_t {
    template<typename C, typename A>
-   conflict_element_t(C&& c, const test_allocator<A>&) { c(*this); }
+   conflict_element_t(C&& c, A&&) { c(*this); }
    uint64_t id;
    int x0;
    int x1;
@@ -499,154 +700,208 @@ struct conflict_element_t {
 };
 
 EXCEPTION_TEST_CASE(test_modify_conflict) {
-   chainbase::undo_index<conflict_element_t, test_allocator<conflict_element_t>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::x0>>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::x1>>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::x2>>> i0;
-   // insert 3 elements
-   i0.emplace([](conflict_element_t& elem) { elem.x0 = 0; elem.x1 = 10; elem.x2 = 10; });
-   i0.emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 1; elem.x2 = 11; });
-   i0.emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 2; });
-   {
-   auto session = i0.start_undo_session(true);
-   // set them to a different value
-   i0.modify(*i0.find(0), [](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
-   i0.modify(*i0.find(1), [](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
-   i0.modify(*i0.find(2), [](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
-   // create a circular conflict with the original values
-   i0.modify(*i0.find(0), [](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 1; elem.x2 = 10; });
-   i0.modify(*i0.find(1), [](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 2; });
-   i0.modify(*i0.find(2), [](conflict_element_t& elem) { elem.x0 = 0; elem.x1 = 12; elem.x2 = 12; });
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<conflict_element_t, test_allocator<conflict_element_t>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::x0>>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::x1>>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::x2>>> i0(alloc);
+      // insert 3 elements
+      i0.emplace([](conflict_element_t& elem) { elem.x0 = 0; elem.x1 = 10; elem.x2 = 10; });
+      i0.emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 1; elem.x2 = 11; });
+      i0.emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 2; });
+      {
+         auto session = i0.start_undo_session(true);
+         // set them to a different value
+         i0.modify(*i0.find(0), [](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
+         i0.modify(*i0.find(1), [](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
+         i0.modify(*i0.find(2), [](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
+         // create a circular conflict with the original values
+         i0.modify(*i0.find(0), [](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 1; elem.x2 = 10; });
+         i0.modify(*i0.find(1), [](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 2; });
+         i0.modify(*i0.find(2), [](conflict_element_t& elem) { elem.x0 = 0; elem.x1 = 12; elem.x2 = 12; });
+      }
+      BOOST_TEST(i0.find(0)->x0 == 0);
+      BOOST_TEST(i0.find(1)->x1 == 1);
+      BOOST_TEST(i0.find(2)->x2 == 2);
+      // Check lookup in the other indices
+      BOOST_TEST(i0.get<1>().find(0)->x0 == 0);
+      BOOST_TEST(i0.get<1>().find(11)->x0 == 11);
+      BOOST_TEST(i0.get<1>().find(12)->x0 == 12);
+      BOOST_TEST(i0.get<2>().find(10)->x1 == 10);
+      BOOST_TEST(i0.get<2>().find(1)->x1 == 1);
+      BOOST_TEST(i0.get<2>().find(12)->x1 == 12);
+      BOOST_TEST(i0.get<3>().find(10)->x2 == 10);
+      BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
+      BOOST_TEST(i0.get<3>().find(2)->x2 == 2);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->x0 == 0);
-   BOOST_TEST(i0.find(1)->x1 == 1);
-   BOOST_TEST(i0.find(2)->x2 == 2);
-   // Check lookup in the other indices
-   BOOST_TEST(i0.get<1>().find(0)->x0 == 0);
-   BOOST_TEST(i0.get<1>().find(11)->x0 == 11);
-   BOOST_TEST(i0.get<1>().find(12)->x0 == 12);
-   BOOST_TEST(i0.get<2>().find(10)->x1 == 10);
-   BOOST_TEST(i0.get<2>().find(1)->x1 == 1);
-   BOOST_TEST(i0.get<2>().find(12)->x1 == 12);
-   BOOST_TEST(i0.get<3>().find(10)->x2 == 10);
-   BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
-   BOOST_TEST(i0.get<3>().find(2)->x2 == 2);
+   bfs::remove_all( temp );
 }
 
 BOOST_DATA_TEST_CASE(test_insert_fail, boost::unit_test::data::make({true, false}), use_undo) {
-   chainbase::undo_index<conflict_element_t, test_allocator<conflict_element_t>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::x0>>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::x1>>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::x2>>> i0;
-   // insert 3 elements
-   i0.emplace([](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
-   i0.emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
-   i0.emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
-   {
-   auto session = i0.start_undo_session(true);
-   // Insert a value with a duplicate
-   BOOST_CHECK_THROW(i0.emplace([](conflict_element_t& elem) { elem.x0 = 81; elem.x1 = 11; elem.x2 = 91; }), std::logic_error);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<conflict_element_t, test_allocator<conflict_element_t>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::x0>>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::x1>>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::x2>>> i0(alloc);
+      // insert 3 elements
+      i0.emplace([](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
+      i0.emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
+      i0.emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
+      {
+         auto session = i0.start_undo_session(true);
+         // Insert a value with a duplicate
+         BOOST_CHECK_THROW(i0.emplace([](conflict_element_t& elem) { elem.x0 = 81; elem.x1 = 11; elem.x2 = 91; }), std::logic_error);
+      }
+      BOOST_TEST(i0.find(0)->x0 == 10);
+      BOOST_TEST(i0.find(1)->x1 == 11);
+      BOOST_TEST(i0.find(2)->x2 == 12);
+      // Check lookup in the other indices
+      BOOST_TEST(i0.get<1>().find(10)->x0 == 10);
+      BOOST_TEST(i0.get<1>().find(11)->x0 == 11);
+      BOOST_TEST(i0.get<1>().find(12)->x0 == 12);
+      BOOST_TEST(i0.get<2>().find(10)->x1 == 10);
+      BOOST_TEST(i0.get<2>().find(11)->x1 == 11);
+      BOOST_TEST(i0.get<2>().find(12)->x1 == 12);
+      BOOST_TEST(i0.get<3>().find(10)->x2 == 10);
+      BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
+      BOOST_TEST(i0.get<3>().find(12)->x2 == 12);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.find(0)->x0 == 10);
-   BOOST_TEST(i0.find(1)->x1 == 11);
-   BOOST_TEST(i0.find(2)->x2 == 12);
-   // Check lookup in the other indices
-   BOOST_TEST(i0.get<1>().find(10)->x0 == 10);
-   BOOST_TEST(i0.get<1>().find(11)->x0 == 11);
-   BOOST_TEST(i0.get<1>().find(12)->x0 == 12);
-   BOOST_TEST(i0.get<2>().find(10)->x1 == 10);
-   BOOST_TEST(i0.get<2>().find(11)->x1 == 11);
-   BOOST_TEST(i0.get<2>().find(12)->x1 == 12);
-   BOOST_TEST(i0.get<3>().find(10)->x2 == 10);
-   BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
-   BOOST_TEST(i0.get<3>().find(12)->x2 == 12);
+   bfs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_fail) {
-   chainbase::undo_index<conflict_element_t, test_allocator<conflict_element_t>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::x0>>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::x1>>,
-                         boost::multi_index::ordered_unique<key<&conflict_element_t::x2>>> i0;
-   // insert 3 elements
-   i0.emplace([](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
-   i0.emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
-   i0.emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
-   {
-   auto session = i0.start_undo_session(true);
-   // Insert a value with a duplicate
-   i0.emplace([](conflict_element_t& elem) { elem.x0 = 71; elem.x1 = 81; elem.x2 = 91; });
-   BOOST_CHECK_THROW(i0.modify(i0.get(3), [](conflict_element_t& elem) { elem.x0 = 71; elem.x1 = 10; elem.x2 = 91; }), std::logic_error);
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<conflict_element_t, test_allocator<conflict_element_t>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::x0>>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::x1>>,
+                            boost::multi_index::ordered_unique<key<&conflict_element_t::x2>>> i0(alloc);
+      // insert 3 elements
+      i0.emplace([](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
+      i0.emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
+      i0.emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
+      {
+         auto session = i0.start_undo_session(true);
+         // Insert a value with a duplicate
+         i0.emplace([](conflict_element_t& elem) { elem.x0 = 71; elem.x1 = 81; elem.x2 = 91; });
+         BOOST_CHECK_THROW(i0.modify(i0.get(3), [](conflict_element_t& elem) { elem.x0 = 71; elem.x1 = 10; elem.x2 = 91; }), std::logic_error);
+      }
+      BOOST_TEST(i0.get<0>().size() == 3);
+      BOOST_TEST(i0.get<1>().size() == 3);
+      BOOST_TEST(i0.get<2>().size() == 3);
+      BOOST_TEST(i0.get<3>().size() == 3);
+      BOOST_TEST(i0.find(0)->x0 == 10);
+      BOOST_TEST(i0.find(1)->x1 == 11);
+      BOOST_TEST(i0.find(2)->x2 == 12);
+      // Check lookup in the other indices
+      BOOST_TEST(i0.get<1>().find(10)->x0 == 10);
+      BOOST_TEST(i0.get<1>().find(11)->x0 == 11);
+      BOOST_TEST(i0.get<1>().find(12)->x0 == 12);
+      BOOST_TEST(i0.get<2>().find(10)->x1 == 10);
+      BOOST_TEST(i0.get<2>().find(11)->x1 == 11);
+      BOOST_TEST(i0.get<2>().find(12)->x1 == 12);
+      BOOST_TEST(i0.get<3>().find(10)->x2 == 10);
+      BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
+      BOOST_TEST(i0.get<3>().find(12)->x2 == 12);
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
    }
-   BOOST_TEST(i0.get<0>().size() == 3);
-   BOOST_TEST(i0.get<1>().size() == 3);
-   BOOST_TEST(i0.get<2>().size() == 3);
-   BOOST_TEST(i0.get<3>().size() == 3);
-   BOOST_TEST(i0.find(0)->x0 == 10);
-   BOOST_TEST(i0.find(1)->x1 == 11);
-   BOOST_TEST(i0.find(2)->x2 == 12);
-   // Check lookup in the other indices
-   BOOST_TEST(i0.get<1>().find(10)->x0 == 10);
-   BOOST_TEST(i0.get<1>().find(11)->x0 == 11);
-   BOOST_TEST(i0.get<1>().find(12)->x0 == 12);
-   BOOST_TEST(i0.get<2>().find(10)->x1 == 10);
-   BOOST_TEST(i0.get<2>().find(11)->x1 == 11);
-   BOOST_TEST(i0.get<2>().find(12)->x1 == 12);
-   BOOST_TEST(i0.get<3>().find(10)->x2 == 10);
-   BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
-   BOOST_TEST(i0.get<3>().find(12)->x2 == 12);
+   bfs::remove_all( temp );
 }
 
 struct by_secondary {};
 
 BOOST_AUTO_TEST_CASE(test_project) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<boost::multi_index::tag<by_secondary>, key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-   BOOST_TEST(i0.project<by_secondary>(i0.begin()) == i0.get<by_secondary>().begin());
-   BOOST_TEST(i0.project<by_secondary>(i0.end()) == i0.get<by_secondary>().end());
-   BOOST_TEST(i0.project<1>(i0.begin()) == i0.get<by_secondary>().begin());
-   BOOST_TEST(i0.project<1>(i0.end()) == i0.get<by_secondary>().end());
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<boost::multi_index::tag<by_secondary>, key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0.project<by_secondary>(i0.begin()) == i0.get<by_secondary>().begin());
+      BOOST_TEST(i0.project<by_secondary>(i0.end()) == i0.get<by_secondary>().end());
+      BOOST_TEST(i0.project<1>(i0.begin()) == i0.get<by_secondary>().begin());
+      BOOST_TEST(i0.project<1>(i0.end()) == i0.get<by_secondary>().end());
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
+   }
+   bfs::remove_all( temp );
 }
 
 
 EXCEPTION_TEST_CASE(test_remove_tracking_session) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 20; });
-   auto session = i0.start_undo_session(true);
-   auto tracker = i0.track_removed();
-   i0.emplace([](test_element_t& elem) { elem.secondary = 21; });
-   const test_element_t& elem0 = *i0.find(0);
-   const test_element_t& elem1 = *i0.find(1);
-   BOOST_CHECK(!tracker.is_removed(elem0));
-   BOOST_CHECK(!tracker.is_removed(elem1));
-   tracker.remove(elem0);
-   tracker.remove(elem1);
-   BOOST_CHECK(tracker.is_removed(elem0));
-   BOOST_CHECK(tracker.is_removed(elem1));
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 20; });
+      auto session = i0.start_undo_session(true);
+      auto tracker = i0.track_removed();
+      i0.emplace([](test_element_t& elem) { elem.secondary = 21; });
+      const test_element_t& elem0 = *i0.find(0);
+      const test_element_t& elem1 = *i0.find(1);
+      BOOST_CHECK(!tracker.is_removed(elem0));
+      BOOST_CHECK(!tracker.is_removed(elem1));
+      tracker.remove(elem0);
+      tracker.remove(elem1);
+      BOOST_CHECK(tracker.is_removed(elem0));
+      BOOST_CHECK(tracker.is_removed(elem1));
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
+   }
+   bfs::remove_all( temp );
 }
 
 
 EXCEPTION_TEST_CASE(test_remove_tracking_no_session) {
-   chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::id>>,
-                         boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0;
-   i0.emplace([](test_element_t& elem) { elem.secondary = 20; });
-   auto tracker = i0.track_removed();
-   i0.emplace([](test_element_t& elem) { elem.secondary = 21; });
-   const test_element_t& elem0 = *i0.find(0);
-   const test_element_t& elem1 = *i0.find(1);
-   BOOST_CHECK(!tracker.is_removed(elem0));
-   BOOST_CHECK(!tracker.is_removed(elem1));
-   tracker.remove(elem0);
-   tracker.remove(elem1);
-   BOOST_CHECK(tracker.is_removed(elem0));
-   BOOST_CHECK(tracker.is_removed(elem1));
+   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   try {
+      chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<basic_element_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::id>>,
+                            boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
+      i0.emplace([](test_element_t& elem) { elem.secondary = 20; });
+      auto tracker = i0.track_removed();
+      i0.emplace([](test_element_t& elem) { elem.secondary = 21; });
+      const test_element_t& elem0 = *i0.find(0);
+      const test_element_t& elem1 = *i0.find(1);
+      BOOST_CHECK(!tracker.is_removed(elem0));
+      BOOST_CHECK(!tracker.is_removed(elem1));
+      tracker.remove(elem0);
+      tracker.remove(elem1);
+      BOOST_CHECK(tracker.is_removed(elem0));
+      BOOST_CHECK(tracker.is_removed(elem1));
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
+   }
+   bfs::remove_all( temp );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/undo_index.cpp
+++ b/test/undo_index.cpp
@@ -1,5 +1,6 @@
 #include <chainbase/undo_index.hpp>
 #include <chainbase/chainbase.hpp>
+#include <filesystem>
 
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -52,7 +53,7 @@ struct throwing_copy {
 };
 
 namespace bip = boost::interprocess;
-namespace bfs = boost::filesystem;
+namespace fs  = std::filesystem;
 
 template<typename T>
 using test_allocator_base = chainbase::chainbase_node_allocator<T, chainbase::pinnable_mapped_file::segment_manager>;
@@ -110,7 +111,7 @@ BOOST_AUTO_TEST_SUITE(undo_index_tests)
    void name##impl ()
 
 EXCEPTION_TEST_CASE(test_simple) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -130,10 +131,10 @@ EXCEPTION_TEST_CASE(test_simple) {
       element = i0.find(0);
       BOOST_TEST(element == nullptr);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 struct test_element_t {
@@ -168,7 +169,7 @@ auto capture_state(const C& index) {
 }
 
 EXCEPTION_TEST_CASE(test_insert_undo) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -186,14 +187,14 @@ EXCEPTION_TEST_CASE(test_insert_undo) {
       BOOST_TEST(i0.find(0)->secondary == 42);
       BOOST_TEST(i0.find(1) == nullptr);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_squash) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -214,13 +215,13 @@ EXCEPTION_TEST_CASE(test_insert_squash) {
       BOOST_TEST(i0.find(0)->secondary == 42);
       BOOST_TEST(i0.find(1) == nullptr);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );}
+   fs::remove_all( temp );}
 
 EXCEPTION_TEST_CASE(test_insert_push) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -241,14 +242,14 @@ EXCEPTION_TEST_CASE(test_insert_push) {
       BOOST_TEST(i0.find(0)->secondary == 42);
       BOOST_TEST(i0.find(1)->secondary == 12);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_undo) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -265,14 +266,14 @@ EXCEPTION_TEST_CASE(test_modify_undo) {
       }
       BOOST_TEST(i0.find(0)->secondary == 42);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_squash) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -292,14 +293,14 @@ EXCEPTION_TEST_CASE(test_modify_squash) {
       }
       BOOST_TEST(i0.find(0)->secondary == 42);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_push) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -319,14 +320,14 @@ EXCEPTION_TEST_CASE(test_modify_push) {
       BOOST_TEST(!i0.has_undo_session());
       BOOST_TEST(i0.find(0)->secondary == 18);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_remove_undo) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -343,14 +344,14 @@ EXCEPTION_TEST_CASE(test_remove_undo) {
       }
       BOOST_TEST(i0.find(0)->secondary == 42);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_remove_squash) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -370,14 +371,14 @@ EXCEPTION_TEST_CASE(test_remove_squash) {
       }
       BOOST_TEST(i0.find(0)->secondary == 42);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_remove_push) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -397,14 +398,14 @@ EXCEPTION_TEST_CASE(test_remove_push) {
       BOOST_TEST(!i0.has_undo_session());
       BOOST_TEST(i0.find(0) == nullptr);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_modify) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -418,14 +419,14 @@ EXCEPTION_TEST_CASE(test_insert_modify) {
       i0.modify(*i0.find(1), [](test_element_t& elem) { elem.secondary = 24; });
       BOOST_TEST(i0.find(1)->secondary == 24);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_modify_undo) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -445,15 +446,15 @@ EXCEPTION_TEST_CASE(test_insert_modify_undo) {
       BOOST_TEST(i0.find(0)->secondary == 42);
       BOOST_TEST(i0.find(1) == nullptr);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 
 EXCEPTION_TEST_CASE(test_insert_modify_squash) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -475,14 +476,14 @@ EXCEPTION_TEST_CASE(test_insert_modify_squash) {
       BOOST_TEST(i0.find(0)->secondary == 42);
       BOOST_TEST(i0.find(1) == nullptr);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_remove_undo) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -502,14 +503,14 @@ EXCEPTION_TEST_CASE(test_insert_remove_undo) {
       BOOST_TEST(i0.find(0)->secondary == 42);
       BOOST_TEST(i0.find(1) == nullptr);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_remove_squash) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -531,14 +532,14 @@ EXCEPTION_TEST_CASE(test_insert_remove_squash) {
       BOOST_TEST(i0.find(0)->secondary == 42);
       BOOST_TEST(i0.find(1) == nullptr);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_modify_undo) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -557,14 +558,14 @@ EXCEPTION_TEST_CASE(test_modify_modify_undo) {
       }
       BOOST_TEST(i0.find(0)->secondary == 42);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_modify_squash) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -585,14 +586,14 @@ EXCEPTION_TEST_CASE(test_modify_modify_squash) {
       }
       BOOST_TEST(i0.find(0)->secondary == 42);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_remove_undo) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -611,14 +612,14 @@ EXCEPTION_TEST_CASE(test_modify_remove_undo) {
       }
       BOOST_TEST(i0.find(0)->secondary == 42);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_remove_squash) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -639,14 +640,14 @@ EXCEPTION_TEST_CASE(test_modify_remove_squash) {
       }
       BOOST_TEST(i0.find(0)->secondary == 42);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_squash_one) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -664,14 +665,14 @@ EXCEPTION_TEST_CASE(test_squash_one) {
          session2.squash();
       }
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_insert_non_unique) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -683,10 +684,10 @@ EXCEPTION_TEST_CASE(test_insert_non_unique) {
       BOOST_CHECK_THROW(i0.emplace([](test_element_t& elem) { elem.secondary = 42; }),  std::exception);
       BOOST_TEST(i0.find(0)->secondary == 42);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 struct conflict_element_t {
@@ -700,7 +701,7 @@ struct conflict_element_t {
 };
 
 EXCEPTION_TEST_CASE(test_modify_conflict) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -738,14 +739,14 @@ EXCEPTION_TEST_CASE(test_modify_conflict) {
       BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
       BOOST_TEST(i0.get<3>().find(2)->x2 == 2);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 BOOST_DATA_TEST_CASE(test_insert_fail, boost::unit_test::data::make({true, false}), use_undo) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -777,14 +778,14 @@ BOOST_DATA_TEST_CASE(test_insert_fail, boost::unit_test::data::make({true, false
       BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
       BOOST_TEST(i0.get<3>().find(12)->x2 == 12);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 EXCEPTION_TEST_CASE(test_modify_fail) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -821,16 +822,16 @@ EXCEPTION_TEST_CASE(test_modify_fail) {
       BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
       BOOST_TEST(i0.get<3>().find(12)->x2 == 12);
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 struct by_secondary {};
 
 BOOST_AUTO_TEST_CASE(test_project) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -843,15 +844,15 @@ BOOST_AUTO_TEST_CASE(test_project) {
       BOOST_TEST(i0.project<1>(i0.begin()) == i0.get<by_secondary>().begin());
       BOOST_TEST(i0.project<1>(i0.end()) == i0.get<by_secondary>().end());
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 
 EXCEPTION_TEST_CASE(test_remove_tracking_session) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -871,15 +872,15 @@ EXCEPTION_TEST_CASE(test_remove_tracking_session) {
       BOOST_CHECK(tracker.is_removed(elem0));
       BOOST_CHECK(tracker.is_removed(elem1));
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 
 EXCEPTION_TEST_CASE(test_remove_tracking_no_session) {
-   bfs::path temp = bfs::temp_directory_path() / bfs::unique_path();
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
@@ -898,10 +899,10 @@ EXCEPTION_TEST_CASE(test_remove_tracking_no_session) {
       BOOST_CHECK(tracker.is_removed(elem0));
       BOOST_CHECK(tracker.is_removed(elem1));
    } catch ( ... ) {
-      bfs::remove_all( temp );
+      fs::remove_all( temp );
       throw;
    }
-   bfs::remove_all( temp );
+   fs::remove_all( temp );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
[alternate from [PR 14](https://github.com/AntelopeIO/chainbase/pull/14) by @taokayan, description copied]. This builds upon @taokayan's work.

### Reduce offset_node_base memory usage inside the RBtree of chainbase
This PR will reduce the chainbase memory usage

#### old implementation:
* `_parent`, `_left`, `_right`, `_color` consume 32 bytes together (8 bytes each).

#### new implementation
* `_parent`, `_left`, `_right`, `_color` consume 16 bytes (42 + 42 + 42 + 2 bits) together.
*  use -2 (instead of 2) as `erased_flag` since _color is a 2 bit signed int.

#### limitations:

* offset pointers `_parent`, `_left` & `_right` only have signed 42-bit each (so 41-bit absolute value), shifted by two bits thanks to alignment, implying a maximum of chainbase size of 2^43 = 8TB.
* `offset_node_base` objects must always be allocated within the same segment due to the 42-bit offset limit. Using a stack variable of `offset_node_base` is no longer valid (as stack address starts from 0x7fffxxxxxxxx which is too far away from heap addresses).
* possible minor performance impact due to misalignment and extra bit operation required. Or performance could possibly be better thanks to higher memory locality.

#### tested results:
using mainnet snapshot snapshot-308122667.bin.tar.gz:
* old chainbase memory usage: `28799134736`
* memory usage in this PR: `23136280976` (around 20% reduction)

[greg 8/21/2023] retested with the current PR version and confirmed the memory savings as reported by `curl -X POST http://127.0.0.1:8888/v1/db_size/get` after loading snapshot.