### PR TITLE
Add benchmark for undo_index.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ endif()
 
 enable_testing()
 add_subdirectory( test )
+add_subdirectory( benchmark )
 
 if(CHAINBASE_INSTALL_COMPONENT)
    set(INSTALL_COMPONENT_ARGS COMPONENT ${CHAINBASE_INSTALL_COMPONENT} EXCLUDE_FROM_ALL)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB UNIT_TESTS "bench.cpp")
+add_executable( chainbase_bench bench.cpp  )
+target_link_libraries( chainbase_bench  chainbase ${PLATFORM_SPECIFIC_LIBS} )

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -1,0 +1,96 @@
+#include <chainbase/undo_index.hpp>
+#include <chainbase/chainbase.hpp>
+#include <filesystem>
+#include <iostream>
+#include <chrono>
+
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+
+namespace bip = boost::interprocess;
+namespace fs  = std::filesystem;
+namespace bmi = boost::multi_index;
+
+template<typename T>
+using test_allocator_base = chainbase::chainbase_node_allocator<T, chainbase::pinnable_mapped_file::segment_manager>;
+
+template<typename T>
+class test_allocator : public test_allocator_base<T> {
+public:
+   using base = test_allocator_base<T>;
+   test_allocator(chainbase::pinnable_mapped_file::segment_manager *mgr) : base(mgr) {}
+   template<typename U>   test_allocator(const test_allocator<U>& o) : base(o.get_segment_manager()) {}
+   template<typename U>   struct rebind { using other = test_allocator<U>; };
+   typename base::pointer allocate(std::size_t count) {
+      return base::allocate(count);
+   }
+};
+
+
+struct elem_t {
+   template<typename C, typename A> elem_t(C&& c, A&&) { c(*this); }
+   
+   friend std::ostream& operator<<(std::ostream& os, const elem_t& e) { os  << '[' << e.id << ", " << e.val << ']'; return os; }
+      
+   uint64_t id;
+   uint64_t val;
+};
+
+template<typename time_unit = std::milli>
+struct stopwatch
+{
+   stopwatch() { _start = clock::now(); }
+   ~stopwatch() {
+      using duration_t = std::chrono::duration<float, time_unit>;
+      point end = clock::now();
+      float elapsed = std::chrono::duration_cast<duration_t>(end - _start).count();
+      printf("Bench time %14.2fs\n", elapsed / 1000);
+   }
+   using clock = std::chrono::high_resolution_clock;
+   using point = std::chrono::time_point<clock>;
+   point _start;
+};
+
+template<typename T>
+struct key_impl;
+template<typename C, typename T>
+struct key_impl<T C::*> { template<auto F> using fn = boost::multi_index::member<C, T, F>; };
+
+template<auto Fn>
+using key = typename key_impl<decltype(Fn)>::template fn<Fn>;
+
+
+int main()
+{
+   fs::path temp = fs::temp_directory_path() / "pinnable_mapped_file";
+   try {
+      constexpr size_t num_elems = 32 * 1024 * 1024;
+      chainbase::pinnable_mapped_file db(temp, true, 64 * num_elems, false, chainbase::pinnable_mapped_file::map_mode::mapped);
+      test_allocator<elem_t> alloc(db.get_segment_manager());
+      chainbase::undo_index<elem_t, test_allocator<elem_t>, bmi::ordered_unique<key<&elem_t::id>>> i0(alloc);
+      boost::random::mt19937 gen;
+      boost::random::uniform_int_distribution<> dist(1, num_elems);
+      
+      stopwatch sw;
+      for (size_t i=0; i<num_elems; ++i) {
+         size_t id = dist(gen);
+         const elem_t* e = i0.find(id);
+         if (e) {
+            //std::cout << *e << '\n';
+            i0.modify(*e, [old=e](elem_t& e) { e.val = old->val + 1; });
+         } else {
+            auto &e = i0.emplace([](elem_t& e) { e.val = 0; });
+            if (e.id % 5 == 0)
+               i0.remove(e);
+         }
+      }
+   } catch (...) {
+      fs::remove_all(temp);
+      throw;
+   }
+   fs::remove_all(temp);
+   return 0;
+}


### PR DESCRIPTION
This PR adds a `benchmark` directory containing a benchmark designed to exercise the `undo_index` specifically.
I ran it 9 times with the older version of chainbase (before the memory optimization) and identically 9 times with the newer version (using 42 bit offsets as pointers for memory efficiency).

The memory optimized version does not appear to be significantly slower (test with gcc_12, release build, AMD 7950x). These numbers show an average 3.05% slowdown with the memory optimization with intensive chainbase use, so I would not expect to see a noticable slowdown in leap.

| Before memory opt | |
|---------|--------|
|Bench time |     13.39s|
|Bench time |     12.42s|
|Bench time |     12.58s|
|Bench time |     12.36s|
|Bench time |     13.49s|
|Bench time |     12.69s|
|Bench time |     12.41s|
|Bench time |     12.33s|
|Bench time |     12.54s|

| After memory opt   | |
| --------|---------|
|Bench time |     12.93s|
|Bench time |     12.66s|
|Bench time |     12.91s|
|Bench time |     12.76s|
|Bench time |     13.13s|
|Bench time |     12.56s|
|Bench time |     12.54s|
|Bench time |     13.34s|
|Bench time |     12.56s|
