### PR TITLE
Improve `mapped` and `head` modes.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        os: ["debian:buster", "ubuntu:jammy"]
+        os: ["debian:bullseye", "ubuntu:jammy"]
     container: ${{matrix.os}}
     steps:
       - name: Install deps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ IF( WIN32 )
 ENDIF(WIN32)
 
 if(NOT TARGET Boost::unit_test_framework)
-   FIND_PACKAGE(Boost 1.67 REQUIRED COMPONENTS system unit_test_framework)
+   FIND_PACKAGE(Boost 1.67 REQUIRED COMPONENTS random system unit_test_framework)
 endif()
 
 SET(PLATFORM_LIBRARIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ IF( WIN32 )
 ENDIF(WIN32)
 
 if(NOT TARGET Boost::unit_test_framework)
-   FIND_PACKAGE(Boost 1.67 REQUIRED COMPONENTS random system unit_test_framework)
+   FIND_PACKAGE(Boost 1.74 REQUIRED COMPONENTS random system unit_test_framework)
 endif()
 
 SET(PLATFORM_LIBRARIES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,9 @@ endif()
 SET(PLATFORM_LIBRARIES)
 
 if(CMAKE_CXX_STANDARD EQUAL 98)
-   message(FATAL_ERROR "chainbase requires c++17 or newer")
+   message(FATAL_ERROR "chainbase requires c++20 or newer")
 elseif(NOT CMAKE_CXX_STANDARD)
-   set(CMAKE_CXX_STANDARD 17)
+   set(CMAKE_CXX_STANDARD 20)
    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ IF( WIN32 )
 ENDIF(WIN32)
 
 if(NOT TARGET Boost::unit_test_framework)
-   FIND_PACKAGE(Boost 1.74 REQUIRED COMPONENTS random system unit_test_framework)
+   FIND_PACKAGE(Boost 1.67 REQUIRED COMPONENTS system unit_test_framework)
 endif()
 
 SET(PLATFORM_LIBRARIES)
@@ -95,7 +95,7 @@ endif()
 
 enable_testing()
 add_subdirectory( test )
-add_subdirectory( benchmark )
+#add_subdirectory( benchmark )
 
 if(CHAINBASE_INSTALL_COMPONENT)
    set(INSTALL_COMPONENT_ARGS COMPONENT ${CHAINBASE_INSTALL_COMPONENT} EXCLUDE_FROM_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ endif()
 
 enable_testing()
 add_subdirectory( test )
-#add_subdirectory( benchmark )
+add_subdirectory( benchmark )
 
 if(CHAINBASE_INSTALL_COMPONENT)
    set(INSTALL_COMPONENT_ARGS COMPONENT ${CHAINBASE_INSTALL_COMPONENT} EXCLUDE_FROM_ALL)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Dependencies
 
-  - C++17
+  - C++20
   - [Boost](http://www.boost.org/)
   - CMake Build Process
   - Supports Linux, Mac OS X  (no Windows Support)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,10 @@ boost::multi_index_container.  This means that two or more threads may read the 
 same time, but all writes must be protected by a mutex.  
 
 Multiple processes may open the same database if care is taken to use interprocess locking on the
-database.  
+database.
+
+When using the `map_mode = mapped_private`, it is not thread-safe to construct a new chainbase instance 
+in one thread while other threads are writing to other chainbase databases.
 
 ## Persistence
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,3 +1,3 @@
 file(GLOB UNIT_TESTS "bench.cpp")
 add_executable( chainbase_bench bench.cpp  )
-target_link_libraries( chainbase_bench  chainbase Boost::random ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( chainbase_bench  chainbase ${PLATFORM_SPECIFIC_LIBS} )

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,3 +1,3 @@
 file(GLOB UNIT_TESTS "bench.cpp")
 add_executable( chainbase_bench bench.cpp  )
-target_link_libraries( chainbase_bench  chainbase ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( chainbase_bench  chainbase Boost::random ${PLATFORM_SPECIFIC_LIBS} )

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -524,6 +524,10 @@ namespace chainbase {
             _db_file.revert_to_mapped_mode();
          }
 
+         void check_memory_usage() {
+            _db_file.check_memory_usage();
+         }
+
       private:
          pinnable_mapped_file                                        _db_file;
          bool                                                        _read_only = false;

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -520,8 +520,8 @@ namespace chainbase {
             _read_only_mode = false;
          }
 
-         void revert_to_mapped_mode() {
-            _db_file.revert_to_mapped_mode();
+         void revert_to_private_mode() {
+            _db_file.revert_to_private_mode();
          }
 
          size_t check_memory_and_flush_if_needed() {

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -524,8 +524,8 @@ namespace chainbase {
             _db_file.revert_to_mapped_mode();
          }
 
-         void check_memory_usage() {
-            _db_file.check_memory_usage();
+         size_t check_memory_and_flush_if_needed() {
+            return _db_file.check_memory_and_flush_if_needed();
          }
 
       private:

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -520,6 +520,10 @@ namespace chainbase {
             _read_only_mode = false;
          }
 
+         void revert_to_mapped_mode() {
+            _db_file.revert_to_mapped_mode();
+         }
+
       private:
          pinnable_mapped_file                                        _db_file;
          bool                                                        _read_only = false;

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -20,20 +20,6 @@ namespace bip = boost::interprocess;
 
 class pagemap_accessor {
 public:
-   struct pagemap_entry {
-      uint64_t pfn        : 54;
-      uint64_t soft_dirty : 1;
-      uint64_t exclusive  : 1;
-      uint64_t file_page  : 1;
-      uint64_t swapped    : 1;
-      uint64_t present    : 1;
-
-      void print(uintptr_t addr, const char *name) {
-         // printf("%jx %jx %u %u %u %u %s\n", (uintmax_t)addr, (uintmax_t)pfn, soft_dirty,
-         //        file_page, swapped, present, name);
-      }
-   };
-
    ~pagemap_accessor() {
       _close();
    }
@@ -49,19 +35,6 @@ public:
       return res;
    }
    
-   std::optional<pagemap_entry> get_entry(uintptr_t vaddr) const {
-      uint64_t data;
-      read(vaddr, { &data, 1 });
-      return pagemap_entry {
-         .pfn        = data & (((uint64_t)1 << 54) - 1),
-         .soft_dirty = (data >> 55) & 1,
-         .exclusive  = (data >> 56) & 1,
-         .file_page  = (data >> 61) & 1,
-         .swapped    = (data >> 62) & 1,
-         .present    = (data >> 63) & 1
-      };
-   }
-
    static bool is_marked_dirty(uint64_t entry) {
       return !!(entry & (1Ull << 55));
    }

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -2,17 +2,14 @@
 
 #include <fcntl.h>    // open 
 #include <unistd.h>   // pread, sysconf
-#include <cstring>
 #include <cstdlib> 
 #include <cassert>
-#include <optional>
 #include <iostream>
 #include <fstream>
 #include <filesystem>
 #include <vector>
 #include <span>
-#include <boost/interprocess/managed_external_buffer.hpp>
-#include <boost/interprocess/anonymous_shared_memory.hpp>
+#include <boost/interprocess/managed_mapped_file.hpp>
 
 namespace chainbase {
 

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -63,6 +63,23 @@ public:
       return this->is_marked_dirty(data);
    }
 
+   // /proc/pid/pagemap. This file lets a userspace process find out which physical frame each virtual page
+   // is mapped to. It contains one 64-bit value for each virtual page, containing the following data
+   // (from fs/proc/task_mmu.c, above pagemap_read):
+   // 
+   // Bits 0-54 page frame number (PFN) if present (note: field is zeroed for non-privileged users)
+   // Bits 0-4 swap type if swapped
+   // Bits 5-54 swap offset if swapped
+   // Bit 55 pte is soft-dirty (see Documentation/admin-guide/mm/soft-dirty.rst)
+   // Bit 56 page exclusively mapped (since 4.2)
+   // Bit 57 pte is uffd-wp write-protected (since 5.13) (see Documentation/admin-guide/mm/userfaultfd.rst)
+   // Bits 58-60 zero
+   // Bit 61 page is file-page or shared-anon (since 3.5)
+   // Bit 62 page swapped
+   // Bit 63 page present
+   //
+   // Here we are just checking bit #55 (the soft-dirty bit).
+   // ----------------------------------------------------------------------------------------------------
    bool read(uintptr_t vaddr, std::span<uint64_t> dest_uint64) const {
       if constexpr (!_pagemap_supported)
          return false;

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -1,0 +1,175 @@
+#pragma once
+
+#include <cstring>
+#include <sys/mman.h> // mmap
+#include <fcntl.h>    // open 
+#include <unistd.h>   // pread, sysconf
+#include <cstdlib> 
+#include <cassert>
+#include <optional>
+#include <iostream>
+#include <fstream>
+#include <filesystem>
+#include <vector>
+#include <span>
+
+namespace chainbase {
+
+class pagemap_accessor {
+public:
+   template<typename F>
+   class scoped_exit {
+   public:
+      template<typename C>
+      [[nodiscard]] scoped_exit(C&& c): callback(std::forward<C>(c)){}
+
+      scoped_exit(scoped_exit&& mv) = default;
+      scoped_exit(const scoped_exit&) = delete;
+      scoped_exit& operator=(const scoped_exit&) = delete;
+
+      ~scoped_exit() { try { callback(); } catch(...) {} }
+   private:
+      F callback;
+   };
+
+   template<typename F>
+   static scoped_exit<F> make_scoped_exit(F&& c) { return scoped_exit<F>(std::forward<F>(c)); }
+   
+   struct pagemap_entry {
+      uint64_t pfn        : 54;
+      uint64_t soft_dirty : 1;
+      uint64_t exclusive  : 1;
+      uint64_t file_page  : 1;
+      uint64_t swapped    : 1;
+      uint64_t present    : 1;
+
+      void print(uintptr_t addr, const char *name) {
+         // printf("%jx %jx %u %u %u %u %s\n", (uintmax_t)addr, (uintmax_t)pfn, soft_dirty,
+         //        file_page, swapped, present, name);
+      }
+   };
+
+   ~pagemap_accessor() {
+      _close();
+   }
+
+   void clear_refs() const {
+      int fd = ::open("/proc/self/clear_refs", O_WRONLY);
+      if (fd < 0) {
+         perror("open clear_refs file failed");
+         exit(1);
+      }
+      auto cleanup = make_scoped_exit([fd] { ::close(fd); });
+      
+      const char *v = "4";
+      if (write(fd, v, 1) < 1) {
+         perror("Can't clear soft-dirty bit");
+         exit(1);
+      }
+   }
+   
+   std::optional<pagemap_entry> get_entry(uintptr_t vaddr) const {
+      uint64_t data;
+      read(vaddr, { &data, 1 });
+      return pagemap_entry {
+         .pfn        = data & (((uint64_t)1 << 54) - 1),
+         .soft_dirty = (data >> 55) & 1,
+         .exclusive  = (data >> 56) & 1,
+         .file_page  = (data >> 61) & 1,
+         .swapped    = (data >> 62) & 1,
+         .present    = (data >> 63) & 1
+      };
+   }
+
+   static bool is_marked_dirty(uint64_t entry) {
+      return !!(entry & (1Ull << 55));
+   }
+
+   static size_t page_size() {
+      return pagesz;
+   }
+
+   bool page_dirty(uintptr_t vaddr) const {
+      uint64_t data;
+      read(vaddr, { &data, 1 });
+      return this->is_marked_dirty(data);
+   }
+
+   bool read(uintptr_t vaddr, std::span<uint64_t> dest_uint64) const {
+      _open(); // make sure file is open
+      assert(_pagemap_fd >= 0);
+      auto dest = std::as_writable_bytes(dest_uint64);
+      std::byte* cur = dest.data();
+      size_t bytes_remaining = dest.size();
+      uintptr_t offset = (vaddr / pagesz) * sizeof(uint64_t);
+      while (bytes_remaining != 0) {
+         ssize_t ret = pread(_pagemap_fd, cur, bytes_remaining, offset + (cur - dest.data()));
+         if (ret < 0) {
+            perror("Can't read pagemap");
+            exit(1);
+            return false;
+         }
+         bytes_remaining -= (size_t)ret;
+         cur += ret;
+      }
+      return true;
+   }
+
+   // copies the modified pages with the virtual address space specified by `rgn` to an
+   // equivalent region starting at `offest` within the (open) file pointed by `fd`.
+   // The specified region *must* be a multiple of the system's page size, and the specified
+   // regioon should exist in the disk file.
+   // --------------------------------------------------------------------------------------
+   bool update_file_from_region(std::span<std::byte> rgn, int fd, size_t offset, bool flush) const {
+      assert(rgn.size() % pagesz == 0);
+      size_t num_pages = rgn.size() / pagesz;
+      std::vector<uint64_t> pm(num_pages);
+      
+      // get modified pages
+      read((uintptr_t)rgn.data(), pm);
+      
+      std::byte* mapping = (std::byte*)mmap(NULL, rgn.size(), PROT_READ|PROT_WRITE, MAP_SHARED, fd, offset);
+      if (mapping) {
+         auto cleanup = make_scoped_exit([&] { munmap(mapping, rgn.size()); });
+         for (size_t i=0; i<num_pages; ++i) {
+            if (is_marked_dirty(pm[i])) {
+               size_t j = i + 1;
+               while (j<num_pages && is_marked_dirty(pm[j]))
+                  ++j;
+               std::byte *dest = mapping + (i * pagesz);
+               size_t length = pagesz * (j - i);
+               memcpy(dest, rgn.data() + (i * pagesz), length);
+               if (flush)
+                  msync(dest, length, MS_SYNC);
+               i += j - i - 1;
+            }
+         }
+         return true;
+      }
+      return false;
+   }
+   
+private:
+   void _open() const {
+      if (_pagemap_fd < 0) {
+         _pagemap_fd = ::open("/proc/self/pagemap", O_RDONLY);
+         if (_pagemap_fd < 0) {
+            perror("open pagemap failed");
+            exit(1);
+         }
+      }
+   }
+
+   void _close() {
+      if (_pagemap_fd >= 0) {
+         ::close(_pagemap_fd);
+         _pagemap_fd = -1;
+      }
+   }
+   
+   static inline size_t pagesz = sysconf(_SC_PAGE_SIZE);
+   
+   mutable int _pagemap_fd = -1;
+};
+
+} // namespace chainbase

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -32,6 +32,12 @@ public:
       if (fd < 0)
          return false;
       
+      // Clear soft-dirty bits from the task's PTEs.
+      // This is done by writing "4" into the /proc/PID/clear_refs file of the task in question.
+      // 
+      // After this, when the task tries to modify a page at some virtual address, the #PF occurs
+      // and the kernel sets the soft-dirty bit on the respective PTE.
+      // ----------------------------------------------------------------------------------------
       const char *v = "4";
       bool res = write(fd, v, 1) == 1;
       ::close(fd);
@@ -81,7 +87,7 @@ public:
    // copies the modified pages with the virtual address space specified by `rgn` to an
    // equivalent region starting at `offest` within the (open) file pointed by `fd`.
    // The specified region *must* be a multiple of the system's page size, and the specified
-   // regioon should exist in the disk file.
+   // region should exist in the disk file.
    // --------------------------------------------------------------------------------------
    bool update_file_from_region(std::span<std::byte> rgn, bip::file_mapping& mapping, size_t offset, bool flush) const {
       if constexpr (!_pagemap_supported)

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -103,7 +103,7 @@ public:
    // The specified region *must* be a multiple of the system's page size, and the specified
    // region should exist in the disk file.
    // --------------------------------------------------------------------------------------
-   bool update_file_from_region(std::span<std::byte> rgn, bip::file_mapping& mapping, size_t offset, bool flush) const {
+   bool update_file_from_region(std::span<std::byte> rgn, bip::file_mapping& mapping, size_t offset, bool flush, size_t& written_pages) const {
       if constexpr (!_pagemap_supported)
          return false;
       
@@ -123,6 +123,7 @@ public:
                while (j<num_pages && is_marked_dirty(pm[j]))
                   ++j;
                memcpy(dest + (i * pagesz), rgn.data() + (i * pagesz), pagesz * (j - i));
+               written_pages += (j - i);
                i += j - i - 1;
             }
          }

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -143,7 +143,7 @@ public:
             }
          }
          if (flush)
-            map_rgn.flush();
+            map_rgn.flush(0, rgn.size(), /* async = */ false);
          return true;
       }
       return false;

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -136,14 +136,12 @@ public:
                size_t j = i + 1;
                while (j<num_pages && is_marked_dirty(pm[j]))
                   ++j;
-               std::byte *dest = mapping + (i * pagesz);
-               size_t length = pagesz * (j - i);
-               memcpy(dest, rgn.data() + (i * pagesz), length);
-               if (flush)
-                  msync(dest, length, MS_SYNC);
+               memcpy(mapping + (i * pagesz), rgn.data() + (i * pagesz), pagesz * (j - i));
                i += j - i - 1;
             }
          }
+         if (flush)
+            msync(mapping, rgn.size(), MS_SYNC);
          return true;
       }
       return false;

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -65,17 +65,17 @@ class pinnable_mapped_file {
       void                                          save_database_file(bool flush = true);
       static bool                                   all_zeros(const std::byte* data, size_t sz);
       void                                          setup_non_file_mapping();
-      std::pair<std::byte*, size_t>                 get_mapped_region() const;
+      std::pair<std::byte*, size_t>                 get_region_to_save() const;
 
       bip::file_lock                                _mapped_file_lock;
       std::filesystem::path                         _data_file_path;
       std::string                                   _database_name;
+      size_t                                        _database_size;
       bool                                          _writable;
       bool                                          _sharable;
 
       bip::file_mapping                             _file_mapping;
       bip::mapped_region                            _file_mapped_region;
-      size_t                                        _file_mapped_region_size;
       void*                                         _non_file_mapped_mapping = nullptr;
       size_t                                        _non_file_mapped_mapping_size = 0;
 

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -67,6 +67,7 @@ class pinnable_mapped_file {
       std::string                                   _database_name;
       bool                                          _writable;
       bool                                          _sharable;
+      bool                                          _pagemap_update_on_exit;
 
       bip::file_mapping                             _file_mapping;
       bip::mapped_region                            _file_mapped_region;

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -22,7 +22,9 @@ enum db_error_code {
    bad_header,
    no_access,
    aborted,
-   no_mlock
+   no_mlock,
+   clear_refs_failed,
+   pagemap_update_failed
 };
 
 const std::error_category& chainbase_error_category();
@@ -43,7 +45,7 @@ class pinnable_mapped_file {
 
       enum map_mode {
          mapped,        // file is mmaped in MAP_PRIVATE mode, and only updated at exit
-         mapped_shared, // file is mmaped in MAP_SHARED mode, and changes can be seen by another chainbase instance
+         mapped_shared, // file is mmaped in MAP_SHARED mode. Only mode where changes can be seen by another chainbase instance
          heap,          // file is copied at startup to an anonymous mapping using huge pages (if available)
          locked         // file is copied at startup to an anonymous mapping using huge pages (if available) and locked in memory
       };

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -23,8 +23,7 @@ enum db_error_code {
    no_access,
    aborted,
    no_mlock,
-   clear_refs_failed,
-   pagemap_update_failed
+   clear_refs_failed
 };
 
 const std::error_category& chainbase_error_category();

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -59,6 +59,8 @@ class pinnable_mapped_file {
 
       segment_manager* get_segment_manager() const { return _segment_manager;}
       void             revert_to_mapped_mode();
+      void             check_memory_usage();
+
 
    private:
       void                                          set_mapped_file_db_dirty(bool);

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -23,7 +23,8 @@ enum db_error_code {
    no_access,
    aborted,
    no_mlock,
-   clear_refs_failed
+   clear_refs_failed,
+   tempfs_incompatible_mode
 };
 
 const std::error_category& chainbase_error_category();

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -46,8 +46,8 @@ class pinnable_mapped_file {
       };
 
       pinnable_mapped_file(const std::filesystem::path& dir, bool writable, uint64_t shared_file_size, bool allow_dirty, map_mode mode);
-      pinnable_mapped_file(pinnable_mapped_file&& o);
-      pinnable_mapped_file& operator=(pinnable_mapped_file&&);
+      pinnable_mapped_file(pinnable_mapped_file&& o) noexcept ;
+      pinnable_mapped_file& operator=(pinnable_mapped_file&&) noexcept ;
       pinnable_mapped_file(const pinnable_mapped_file&) = delete;
       pinnable_mapped_file& operator=(const pinnable_mapped_file&) = delete;
       ~pinnable_mapped_file();
@@ -68,6 +68,7 @@ class pinnable_mapped_file {
 
       bip::file_mapping                             _file_mapping;
       bip::mapped_region                            _file_mapped_region;
+      size_t                                        _file_mapped_region_size;
       void*                                         _non_file_mapped_mapping = nullptr;
       size_t                                        _non_file_mapped_mapping_size = 0;
 

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -44,8 +44,8 @@ class pinnable_mapped_file {
       typedef typename bip::managed_mapped_file::segment_manager segment_manager;
 
       enum map_mode {
-         mapped,        // file is mmaped in MAP_PRIVATE mode, and only updated at exit
-         mapped_shared, // file is mmaped in MAP_SHARED mode. Only mode where changes can be seen by another chainbase instance
+         mapped,        // file is mmaped in MAP_SHARED mode. Only mode where changes can be seen by another chainbase instance
+         mapped_private,// file is mmaped in MAP_PRIVATE mode, and only updated at exit
          heap,          // file is copied at startup to an anonymous mapping using huge pages (if available)
          locked         // file is copied at startup to an anonymous mapping using huge pages (if available) and locked in memory
       };
@@ -58,7 +58,7 @@ class pinnable_mapped_file {
       ~pinnable_mapped_file();
 
       segment_manager* get_segment_manager() const { return _segment_manager;}
-      void             revert_to_mapped_mode();
+      void             revert_to_private_mode();
       size_t           check_memory_and_flush_if_needed();
 
 

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -58,6 +58,7 @@ class pinnable_mapped_file {
       ~pinnable_mapped_file();
 
       segment_manager* get_segment_manager() const { return _segment_manager;}
+      void             revert_to_mapped_mode();
 
    private:
       void                                          set_mapped_file_db_dirty(bool);
@@ -65,6 +66,7 @@ class pinnable_mapped_file {
       void                                          save_database_file(bool flush = true);
       static bool                                   all_zeros(const std::byte* data, size_t sz);
       void                                          setup_non_file_mapping();
+      void                                          setup_copy_on_write_mapping();
       std::pair<std::byte*, size_t>                 get_region_to_save() const;
 
       bip::file_lock                                _mapped_file_lock;

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -59,7 +59,7 @@ class pinnable_mapped_file {
 
       segment_manager* get_segment_manager() const { return _segment_manager;}
       void             revert_to_mapped_mode();
-      void             check_memory_usage();
+      size_t           check_memory_and_flush_if_needed();
 
 
    private:

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -279,14 +279,11 @@ void pinnable_mapped_file::save_database_file(const char* src, size_t sz) {
    size_t offset = 0;
    time_t t = time(nullptr);
    pagemap_accessor pagemap;
-   bip::file_mapping  mapping;
-   if (_pagemap_update_on_exit) 
-      mapping = bip::file_mapping(_data_file_path.generic_string().c_str(),   bip::read_write);
    
    while(offset != sz) {
       size_t copy_size = std::min(_db_size_copy_increment, sz - offset);
       if (_pagemap_update_on_exit) {
-         pagemap.update_file_from_region({ (std::byte*)(src+offset), copy_size }, mapping, offset, true);
+         pagemap.update_file_from_region({ (std::byte*)(src+offset), copy_size }, _file_mapping, offset, true);
       } else {
          if(!all_zeros(src+offset, copy_size)) {
             bip::mapped_region dst_rgn(_file_mapping, bip::read_write, offset, copy_size);

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -327,7 +327,7 @@ void pinnable_mapped_file::load_database_file(boost::asio::io_service& sig_ios) 
       if(time(nullptr) != t) {
          t = time(nullptr);
          std::cerr << "CHAINBASE: Preloading \"" << _database_name << "\" database file, " <<
-            offset/(_file_mapped_region.get_size()/100) << "% complete..." << '\n';
+            offset/(_database_size/100) << "% complete..." << '\n';
       }
       sig_ios.poll();
    }

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -404,7 +404,6 @@ void pinnable_mapped_file::save_database_file(bool flush /* = true */) {
             memcpy(dst, src+offset, copy_size);
 
             if (flush) {
-               std::cerr << "CHAINBASE: Writing \"" << _database_name << "\" database file, flushing buffers..." << '\n';
                if(dst_rgn.flush(0, 0, false) == false)
                   std::cerr << "CHAINBASE: ERROR: flushing buffers failed" << '\n';
             }

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -43,6 +43,8 @@ std::string chainbase_error_category::message(int ev) const {
          return "Database load aborted";
       case db_error_code::no_mlock:
          return "Failed to mlock database";
+      case db_error_code::clear_refs_failed:
+         return "Failed to clear Soft-Dirty bits";
       default:
          return "Unrecognized error code";
    }

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -1,8 +1,6 @@
 #include <chainbase/pinnable_mapped_file.hpp>
 #include <chainbase/environment.hpp>
 #include <chainbase/pagemap_accessor.hpp>
-#include <boost/interprocess/managed_external_buffer.hpp>
-#include <boost/interprocess/anonymous_shared_memory.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <iostream>
 #include <fstream>

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -279,15 +279,14 @@ void pinnable_mapped_file::save_database_file(const char* src, size_t sz) {
    size_t offset = 0;
    time_t t = time(nullptr);
    pagemap_accessor pagemap;
-   int fd = -1;
+   bip::file_mapping  mapping;
    if (_pagemap_update_on_exit) 
-      fd = open(_data_file_path.generic_string().c_str(),  O_RDWR);
-   auto cleanup = pagemap_accessor::make_scoped_exit([fd] { if (fd >= 0) close(fd); });
+      mapping = bip::file_mapping(_data_file_path.generic_string().c_str(),   bip::read_write);
    
    while(offset != sz) {
       size_t copy_size = std::min(_db_size_copy_increment, sz - offset);
       if (_pagemap_update_on_exit) {
-         pagemap.update_file_from_region({ (std::byte*)(src+offset), copy_size }, fd, offset, true);
+         pagemap.update_file_from_region({ (std::byte*)(src+offset), copy_size }, mapping, offset, true);
       } else {
          if(!all_zeros(src+offset, copy_size)) {
             bip::mapped_region dst_rgn(_file_mapping, bip::read_write, offset, copy_size);

--- a/test/grow_shrink.cpp
+++ b/test/grow_shrink.cpp
@@ -7,7 +7,7 @@ using namespace chainbase;
 
 const pinnable_mapped_file::map_mode test_modes[] = {
    pinnable_mapped_file::map_mode::mapped,
-   pinnable_mapped_file::map_mode::mapped_shared,
+   pinnable_mapped_file::map_mode::mapped_private,
    pinnable_mapped_file::map_mode::heap
 };
 

--- a/test/grow_shrink.cpp
+++ b/test/grow_shrink.cpp
@@ -5,7 +5,11 @@
 #include "temp_directory.hpp"
 using namespace chainbase;
 
-const pinnable_mapped_file::map_mode test_modes[] = {pinnable_mapped_file::map_mode::mapped, pinnable_mapped_file::map_mode::heap};
+const pinnable_mapped_file::map_mode test_modes[] = {
+   pinnable_mapped_file::map_mode::mapped,
+   pinnable_mapped_file::map_mode::mapped_shared,
+   pinnable_mapped_file::map_mode::heap
+};
 
 BOOST_DATA_TEST_CASE(grow_shrink, boost::unit_test::data::make(test_modes), map_mode) {
    temp_directory temp_dir;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE( open_and_create ) {
    const auto& temp = temp_dir.path();
    std::cerr << temp << " \n";
 
-   chainbase::database db(temp, database::read_write, 1024*1024*8);
+   chainbase::database db(temp, database::read_write, 1024*1024*8, false, pinnable_mapped_file::map_mode::mapped_shared);
    chainbase::database db2(temp, database::read_only, 0, true); /// open an already created db
    BOOST_CHECK_THROW( db2.add_index< book_index >(), std::runtime_error ); /// index does not exist in read only database
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE( open_and_create ) {
    const auto& temp = temp_dir.path();
    std::cerr << temp << " \n";
 
-   chainbase::database db(temp, database::read_write, 1024*1024*8, false, pinnable_mapped_file::map_mode::mapped_shared);
+   chainbase::database db(temp, database::read_write, 1024*1024*8, false, pinnable_mapped_file::map_mode::mapped);
    chainbase::database db2(temp, database::read_only, 0, true); /// open an already created db
    BOOST_CHECK_THROW( db2.add_index< book_index >(), std::runtime_error ); /// index does not exist in read only database
 


### PR DESCRIPTION
- __issue with `heap` mode__: at leap startup and exit, we perform a `memcpy` copy between two mappings of the full database size. This causes significant pressure on the file cache when physical RAM is less than 2x the database size 

  __=> solution: use a series of smaller mappings for the copy, reducing RAM contention.

- __issue with `mapped` mode__:  when leap is running, linux will grind the disk into dust with its default dirty writeback algo. it's also a perf killer.

  __=> solution__: map the file with `MAP_PRIVATE` (so changes are not written back to the file), and on exit copy just the modified pages using a series of RW mappings (info on which pages are dirty is gathered using the [pagemap](https://www.kernel.org/doc/Documentation/admin-guide/mm/pagemap.rst) interface. Should we still set the `dirty` bit in the db file at startup?
  
  This new implementation of `mapped` mode, as well as the existing `heap` and `locked` modes, does not allow sharing an opened database in RW mode with other instances in RO mode. In order to not completely remove the sharing functionality (tested in test.cpp), a new `mapped_shared` mode is introduced, which is the same as the old `mapped` mode.

Also:
- update minimum C++ standard requirement to `C++20`
- update ci/cd platform from `debian:buster` to `debian:bullseye` to get `c++20` support (`std::span`)