### PR TITLE
Increment chainbase version tag.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ endif()
 
 enable_testing()
 add_subdirectory( test )
-#add_subdirectory( benchmark )
+add_subdirectory( benchmark )
 
 if(CHAINBASE_INSTALL_COMPONENT)
    set(INSTALL_COMPONENT_ARGS COMPONENT ${CHAINBASE_INSTALL_COMPONENT} EXCLUDE_FROM_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ endif()
 
 enable_testing()
 add_subdirectory( test )
-add_subdirectory( benchmark )
+#add_subdirectory( benchmark )
 
 if(CHAINBASE_INSTALL_COMPONENT)
    set(INSTALL_COMPONENT_ARGS COMPONENT ${CHAINBASE_INSTALL_COMPONENT} EXCLUDE_FROM_ALL)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,3 +1,3 @@
 file(GLOB UNIT_TESTS "bench.cpp")
-add_executable( chainbase_bench bench.cpp  )
+add_executable( chainbase_bench EXCLUDE_FROM_ALL bench.cpp  )
 target_link_libraries( chainbase_bench  chainbase ${PLATFORM_SPECIFIC_LIBS} )

--- a/include/chainbase/environment.hpp
+++ b/include/chainbase/environment.hpp
@@ -5,7 +5,7 @@
 namespace chainbase {
 
 constexpr size_t header_size = 1024;
-constexpr uint64_t header_id = 0x3242444f49534f45ULL; //"EOSIODB2" little endian
+constexpr uint64_t header_id = 0x3342444f49534f45ULL; //"EOSIODB3" little endian
 
 struct environment  {
    environment() {


### PR DESCRIPTION
Fix for [Leap #1570 issue](https://github.com/AntelopeIO/leap/issues/1570).

- increment version tag to `"EOSIODB3"` little endian (previous was `"EOSIODB2"`, and I wondered if I should switch to `"EOSIODB5"` for Leap 5?)
- I also removed the new `benchmark` dir from the build as it doesn't build within Leap (issue with Boost `random` library) 