### PR TITLE
New mapped_private mode: avoid crash by flushing dirty pages when memory pressure gets high

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,6 @@ endif()
 
 SET(PLATFORM_LIBRARIES)
 
-if(CMAKE_CXX_STANDARD EQUAL 98)
-   message(FATAL_ERROR "chainbase requires c++20 or newer")
-elseif(NOT CMAKE_CXX_STANDARD)
-   set(CMAKE_CXX_STANDARD 20)
-   set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if( APPLE )
   # Apple Specific Options Here
   message( STATUS "Configuring ChainBase on OS X" )
@@ -67,6 +60,7 @@ endif()
 file(GLOB HEADERS "include/chainbase/*.hpp")
 add_library( chainbase src/chainbase.cpp src/pinnable_mapped_file.cpp ${HEADERS} )
 target_link_libraries( chainbase PUBLIC ${PLATFORM_LIBRARIES} Boost::system Boost::unit_test_framework )
+target_compile_features(chainbase PUBLIC cxx_std_20)
 
 if(TARGET Boost::asio)
   target_link_libraries( chainbase PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Defines ChainBase library target.
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.12 )
 project( ChainBase )
 
 #list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules" )

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -524,7 +524,7 @@ namespace chainbase {
             _db_file.revert_to_private_mode();
          }
 
-         size_t check_memory_and_flush_if_needed() {
+         std::optional<std::pair<size_t, size_t>> check_memory_and_flush_if_needed() {
             return _db_file.check_memory_and_flush_if_needed();
          }
 

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -524,7 +524,7 @@ namespace chainbase {
             _db_file.revert_to_private_mode();
          }
 
-         std::optional<std::pair<size_t, size_t>> check_memory_and_flush_if_needed() {
+         std::optional<pinnable_mapped_file::memory_check_result> check_memory_and_flush_if_needed() {
             return _db_file.check_memory_and_flush_if_needed();
          }
 

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -391,6 +391,10 @@ namespace chainbase {
             return _db_file.get_segment_manager();
          }
 
+         pinnable_mapped_file& get_pinnable_mapped_file() {
+            return _db_file;
+         }
+
          size_t get_free_memory()const
          {
             return _db_file.get_segment_manager()->get_free_memory();

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <vector>
 #include <span>
+#include <optional>
 #include <boost/interprocess/managed_mapped_file.hpp>
 
 namespace chainbase {
@@ -21,7 +22,7 @@ public:
       _close();
    }
 
-   bool clear_refs() const {
+   static bool clear_refs() {
       if constexpr (!_pagemap_supported)
          return false;
       
@@ -41,6 +42,22 @@ public:
       return res;
    }
    
+   static std::optional<int> read_oom_score() {
+      if constexpr (!_pagemap_supported)
+         return {};
+      
+      std::ifstream oom_score_file("/proc/self/oom_score");
+
+      if (!oom_score_file.is_open())
+         return {};
+
+      int oom_score;
+      if (!(oom_score_file >> oom_score))
+         return {};
+
+      return oom_score;
+   }
+      
    static constexpr bool pagemap_supported() {
       return _pagemap_supported;
    }

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -82,8 +82,7 @@ class pinnable_mapped_file {
 
       bip::file_mapping                             _file_mapping;
       bip::mapped_region                            _file_mapped_region;
-      void*                                         _cow_mapping = nullptr;
-      size_t                                        _cow_size = 0;
+      void*                                         _cow_address = nullptr;
       void*                                         _non_file_mapped_mapping = nullptr;
       size_t                                        _non_file_mapped_mapping_size = 0;
 

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -5,6 +5,7 @@
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/asio/io_service.hpp>
 #include <filesystem>
+#include <optional>
 #include <vector>
 
 namespace chainbase {
@@ -59,7 +60,7 @@ class pinnable_mapped_file {
 
       segment_manager* get_segment_manager() const { return _segment_manager;}
       void             revert_to_private_mode();
-      size_t           check_memory_and_flush_if_needed();
+      std::optional<std::pair<size_t, size_t>> check_memory_and_flush_if_needed();
 
 
    private:

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -25,7 +25,8 @@ enum db_error_code {
    aborted,
    no_mlock,
    clear_refs_failed,
-   tempfs_incompatible_mode
+   tempfs_incompatible_mode,
+   mmap_address_match_failed
 };
 
 const std::error_category& chainbase_error_category();
@@ -81,6 +82,8 @@ class pinnable_mapped_file {
 
       bip::file_mapping                             _file_mapping;
       bip::mapped_region                            _file_mapped_region;
+      void*                                         _cow_mapping = nullptr;
+      size_t                                        _cow_size = 0;
       void*                                         _non_file_mapped_mapping = nullptr;
       size_t                                        _non_file_mapped_mapping_size = 0;
 

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -66,7 +66,7 @@ class pinnable_mapped_file {
    private:
       void                                          set_mapped_file_db_dirty(bool);
       void                                          load_database_file(boost::asio::io_service& sig_ios);
-      size_t                                        save_database_file(bool flush, bool show_messages);
+      size_t                                        save_database_file(bool flush, bool closing_db);
       static bool                                   all_zeros(const std::byte* data, size_t sz);
       void                                          setup_non_file_mapping();
       void                                          setup_copy_on_write_mapping();

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -67,6 +67,9 @@ class pinnable_mapped_file {
 
       segment_manager* get_segment_manager() const { return _segment_manager;}
       void             revert_to_private_mode();
+      void             set_oom_threshold(int threshold) { _oom_threshold = threshold; }
+      void             set_oom_delay(int seconds)       { _oom_delay = seconds; }
+      std::optional<int> get_oom_score() const;
       std::optional<memory_check_result> check_memory_and_flush_if_needed();
 
 
@@ -99,6 +102,8 @@ class pinnable_mapped_file {
 #endif
 
       segment_manager*                              _segment_manager = nullptr;
+      int                                           _oom_threshold = 980; // for mapped_private mode, flush mapped pages when oon_score > threshold
+      int                                           _oom_delay = 30;      // minimum delay in seconds between threshold checks
 
       static std::vector<pinnable_mapped_file*>     _instance_tracker;
 

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -65,7 +65,7 @@ class pinnable_mapped_file {
    private:
       void                                          set_mapped_file_db_dirty(bool);
       void                                          load_database_file(boost::asio::io_service& sig_ios);
-      void                                          save_database_file(bool flush = true);
+      size_t                                        save_database_file(bool flush = true);
       static bool                                   all_zeros(const std::byte* data, size_t sz);
       void                                          setup_non_file_mapping();
       void                                          setup_copy_on_write_mapping();

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -66,7 +66,7 @@ class pinnable_mapped_file {
    private:
       void                                          set_mapped_file_db_dirty(bool);
       void                                          load_database_file(boost::asio::io_service& sig_ios);
-      size_t                                        save_database_file(bool flush = true);
+      size_t                                        save_database_file(bool flush, bool show_messages);
       static bool                                   all_zeros(const std::byte* data, size_t sz);
       void                                          setup_non_file_mapping();
       void                                          setup_copy_on_write_mapping();

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -52,6 +52,12 @@ class pinnable_mapped_file {
          locked         // file is copied at startup to an anonymous mapping using huge pages (if available) and locked in memory
       };
 
+      struct memory_check_result {
+         int    oom_score_before;
+         int    oom_score_after;
+         size_t num_pages_written;
+      };
+
       pinnable_mapped_file(const std::filesystem::path& dir, bool writable, uint64_t shared_file_size, bool allow_dirty, map_mode mode);
       pinnable_mapped_file(pinnable_mapped_file&& o) noexcept ;
       pinnable_mapped_file& operator=(pinnable_mapped_file&&) noexcept ;
@@ -61,7 +67,7 @@ class pinnable_mapped_file {
 
       segment_manager* get_segment_manager() const { return _segment_manager;}
       void             revert_to_private_mode();
-      std::optional<std::pair<size_t, size_t>> check_memory_and_flush_if_needed();
+      std::optional<memory_check_result> check_memory_and_flush_if_needed();
 
 
    private:

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -265,7 +265,7 @@ void pinnable_mapped_file::revert_to_private_mode() {
 }
 
 // returns the number of pages flushed to disk
-std::optional<std::pair<size_t, size_t>> pinnable_mapped_file::check_memory_and_flush_if_needed() {
+   std::optional<pinnable_mapped_file::memory_check_result> pinnable_mapped_file::check_memory_and_flush_if_needed() {
    size_t written_pages {0};
    if (_non_file_mapped_mapping || _sharable || !_writable)
       return {};
@@ -294,7 +294,7 @@ std::optional<std::pair<size_t, size_t>> pinnable_mapped_file::check_memory_and_
             if (!pagemap_accessor::clear_refs())
                BOOST_THROW_EXCEPTION(std::system_error(make_error_code(db_error_code::clear_refs_failed)));
          } 
-         return std::make_pair(*oom_score, written_pages);
+         return memory_check_result{*oom_score, *pagemap_accessor::read_oom_score(), written_pages};
       }
    }
    return {};

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -432,7 +432,7 @@ size_t pinnable_mapped_file::save_database_file(bool flush, bool closing_db) {
       // we are saving while processing... recreate the copy_on_write mapping with clean pages.
       // --------------------------------------------------------------------------------------
       void* old_addr = _cow_mapping;
-      munmap(_cow_mapping, _database_size);  // first clear old region so we don't overcommit
+      munmap(_cow_mapping, _cow_size);  // first clear old region so we don't overcommit
       _cow_mapping = mmap(_cow_mapping, _cow_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED,
                           _file_mapping.get_mapping_handle().handle, 0);
       if (_cow_mapping != old_addr)

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -233,6 +233,8 @@ void pinnable_mapped_file::setup_copy_on_write_mapping() {
       pmm->save_database_file(true, false);
 
    _cow_address = mmap(NULL, _database_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, _file_mapping.get_mapping_handle().handle, 0);
+   if (_cow_address == MAP_FAILED)
+      BOOST_THROW_EXCEPTION(std::runtime_error(std::string("Failed to map database ") + _database_name + ": " + strerror(errno)));
    *((char*)_cow_address + header_dirty_bit_offset) = dirty; // set dirty bit in our memory mapping
    _segment_manager = reinterpret_cast<segment_manager*>((char*)_cow_address + header_size);
 

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -231,11 +231,9 @@ void pinnable_mapped_file::setup_copy_on_write_mapping() {
    for (auto pmm : _instance_tracker)
       pmm->save_database_file(true, false);
 
-   auto pgsz = pagemap_accessor::page_size();
-   _cow_size = (_database_size + pgsz - 1) & ~(pgsz - 1);
-   _cow_mapping = mmap(NULL, _cow_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, _file_mapping.get_mapping_handle().handle, 0);
-   *((char*)_cow_mapping + header_dirty_bit_offset) = dirty; // set dirty bit in our memory mapping
-   _segment_manager = reinterpret_cast<segment_manager*>((char*)_cow_mapping + header_size);
+   _cow_address = mmap(NULL, _database_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, _file_mapping.get_mapping_handle().handle, 0);
+   *((char*)_cow_address + header_dirty_bit_offset) = dirty; // set dirty bit in our memory mapping
+   _segment_manager = reinterpret_cast<segment_manager*>((char*)_cow_address + header_size);
 
    // then clear the Soft-Dirty bits
    // ------------------------------
@@ -384,8 +382,8 @@ bool pinnable_mapped_file::all_zeros(const std::byte* data, size_t sz) {
 std::pair<std::byte*, size_t> pinnable_mapped_file::get_region_to_save() const {
    if (_non_file_mapped_mapping)
       return { (std::byte*)_non_file_mapped_mapping, _database_size };
-   if (_cow_mapping)
-      return { (std::byte*)_cow_mapping, _database_size };
+   if (_cow_address)
+      return { (std::byte*)_cow_address, _database_size };
    return { (std::byte*)_file_mapped_region.get_address(), _database_size };
 }
 
@@ -431,13 +429,13 @@ size_t pinnable_mapped_file::save_database_file(bool flush, bool closing_db) {
 #ifndef _WIN32
       // we are saving while processing... recreate the copy_on_write mapping with clean pages.
       // --------------------------------------------------------------------------------------
-      void* old_addr = _cow_mapping;
-      munmap(_cow_mapping, _cow_size);  // first clear old region so we don't overcommit
-      _cow_mapping = mmap(_cow_mapping, _cow_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED,
+      void* old_address = _cow_address;
+      munmap(_cow_address, _database_size);  // first clear old region so we don't overcommit
+      _cow_address = mmap(_cow_address, _database_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED,
                           _file_mapping.get_mapping_handle().handle, 0);
-      if (_cow_mapping != old_addr)
+      if (_cow_address != old_address)
          BOOST_THROW_EXCEPTION(std::system_error(make_error_code(db_error_code::mmap_address_match_failed)));
-      assert(*((char*)_cow_mapping + header_dirty_bit_offset) == dirty); 
+      assert(*((char*)_cow_address + header_dirty_bit_offset) == dirty); 
 #endif
    }
    return written_pages;

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -136,9 +136,10 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
             std::filesystem::resize_file(_data_file_path, shared_file_size);
          }
          else if(shared_file_size < existing_file_size) {
-             std::cerr << "CHAINBASE: \"" << _database_name << "\" requested size of " << shared_file_size << " is less than "
-                "existing size of " << existing_file_size << ". This database will not be shrunk and will "
-                "remain at " << existing_file_size << '\n';
+            _database_size = existing_file_size;
+            std::cerr << "CHAINBASE: \"" << _database_name << "\" requested size of " << shared_file_size << " is less than "
+               "existing size of " << existing_file_size << ". This database will not be shrunk and will "
+               "remain at " << existing_file_size << '\n';
          }
          _file_mapping = bip::file_mapping(_data_file_path.generic_string().c_str(), bip::read_write);
          _file_mapped_region = bip::mapped_region(_file_mapping, bip::read_write);

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -289,7 +289,7 @@ std::optional<std::pair<size_t, size_t>> pinnable_mapped_file::check_memory_and_
             // soft-dirty flag
             // -------------------------------------------------------------------------------------------
             for (auto pmm : _instance_tracker)
-               written_pages += pmm->save_database_file(true);
+               written_pages += pmm->save_database_file(false);
             if (!pagemap_accessor::clear_refs())
                BOOST_THROW_EXCEPTION(std::system_error(make_error_code(db_error_code::clear_refs_failed)));
          } 

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -138,8 +138,8 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
          else if(shared_file_size < existing_file_size) {
             _database_size = existing_file_size;
             std::cerr << "CHAINBASE: \"" << _database_name << "\" requested size of " << shared_file_size << " is less than "
-               "existing size of " << existing_file_size << ". This database will not be shrunk and will "
-               "remain at " << existing_file_size << '\n';
+                "existing size of " << existing_file_size << ". This database will not be shrunk and will "
+                "remain at " << existing_file_size << '\n';
          }
          _file_mapping = bip::file_mapping(_data_file_path.generic_string().c_str(), bip::read_write);
          _file_mapped_region = bip::mapped_region(_file_mapping, bip::read_write);

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -437,7 +437,6 @@ size_t pinnable_mapped_file::save_database_file(bool flush, bool closing_db) {
       // we are saving while processing... recreate the copy_on_write mapping with clean pages.
       // --------------------------------------------------------------------------------------
       void* old_address = _cow_address;
-      munmap(_cow_address, _database_size);  // first clear old region so we don't overcommit
       _cow_address = mmap(_cow_address, _database_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED,
                           _file_mapping.get_mapping_handle().handle, 0);
       if (_cow_address != old_address)

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -278,12 +278,14 @@ size_t pinnable_mapped_file::check_memory_and_flush_if_needed() {
       check_time = current_time + check_interval;
 
       auto oom_score = pagemap_accessor::read_oom_score();
-      if (oom_score && *oom_score >= 920) {
+      if (oom_score && *oom_score >= 980) {
          // linux returned a high out-of-memory (oom) score for the current process, indicating a high 
-         // probablility that the process will be killed soon (The valid range is from 0 (never kill) 
-         // to 1000 (always kill). The higher the value is, the higher the probability is that the 
-         // process will be killed).
-         // In order to avoid this, update database file with dirty pages and clear the soft-dirty flag
+         // probablility that the process will be killed soon (The valid range is from 0 to 1000.
+         // The higher the value is, the higher the probability is that the process will be killed).
+         // In my experiments I see processes going above 1000 without being killed, and zeroed on a
+         // threshold of 980.
+         // When this threshold is reached, update database file with dirty pages and clear the
+         // soft-dirty flag
          // -------------------------------------------------------------------------------------------
          for (auto pmm : _instance_tracker)
             written_pages += pmm->save_database_file(true);

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -428,6 +428,7 @@ size_t pinnable_mapped_file::save_database_file(bool flush, bool closing_db) {
    if (closing_db) {
       std::cerr << "CHAINBASE: Writing \"" << _database_name << "\" database file, complete." << '\n';
    } else if (mapped_writable_instance) {
+#ifndef _WIN32
       // we are saving while processing... recreate the copy_on_write mapping with clean pages.
       // --------------------------------------------------------------------------------------
       void* old_addr = _cow_mapping;
@@ -437,7 +438,7 @@ size_t pinnable_mapped_file::save_database_file(bool flush, bool closing_db) {
       if (_cow_mapping != old_addr)
          BOOST_THROW_EXCEPTION(std::system_error(make_error_code(db_error_code::mmap_address_match_failed)));
       assert(*((char*)_cow_mapping + header_dirty_bit_offset) == dirty); 
-      
+#endif
    }
    return written_pages;
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -153,6 +153,9 @@ BOOST_AUTO_TEST_CASE( oom_flush_dirty_pages ) {
                if (++flush_count == 6)
                   break;
             }
+         } else if (!pmf.get_oom_score()) {
+            // oom score not supported on this system - break out of the loop.
+            break;
          }
 
          // check that we still have all previously created items
@@ -170,7 +173,7 @@ BOOST_AUTO_TEST_CASE( oom_flush_dirty_pages ) {
       BOOST_REQUIRE_EQUAL( last_inserted_book.b, (int)(i+1) );
 
    }
-   BOOST_REQUIRE(flush_count == 6); 
+   BOOST_REQUIRE(flush_count == 6 || !pmf.get_oom_score()); 
 }
 
 // BOOST_AUTO_TEST_SUITE_END()

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -158,6 +158,14 @@ BOOST_AUTO_TEST_CASE( oom_flush_dirty_pages ) {
                   break;
             }
          }
+
+         // check that we still have all previously created items
+         for (size_t k=0; k<i; ++k) {
+            const auto& book = db.get( book::id_type(k) );
+            BOOST_REQUIRE_EQUAL( book.a, (int)k );
+            BOOST_REQUIRE_EQUAL( book.b, (int)(k+1) );
+         }
+         
       }
       std::cerr << "index size: " << db.get_index<get_index_type<book>::type>().size() << '\n';
       BOOST_REQUIRE(db.get_index<get_index_type<book>::type>().size() == i+1);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE( oom_flush_dirty_pages ) {
          }
          
       }
-      std::cerr << "index size: " << db.get_index<get_index_type<book>::type>().size() << '\n';
+      BOOST_REQUIRE_EQUAL( db.get_index<get_index_type<book>::type>().size(), i+1);
       BOOST_REQUIRE(db.get_index<get_index_type<book>::type>().size() == i+1);
       const auto& last_inserted_book = db.get( book::id_type(i) );
       BOOST_REQUIRE_EQUAL( last_inserted_book.a, (int)i );

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -142,8 +142,8 @@ BOOST_AUTO_TEST_CASE( oom_flush_dirty_pages ) {
    pmf.set_oom_delay(1);
 
    size_t flush_count = 0;
-   for (int i=0; i<max_elems; ++i) {
-      db.create<book>( [i]( book& b ) { b.a = i; b.b = i+1; } );
+   for (size_t i=0; i<max_elems; ++i) {
+      db.create<book>( [i]( book& b ) { b.a = (int)i; b.b = (int)(i+1); } );
       if (i % 1000 == 0) {
          if (auto res = db.check_memory_and_flush_if_needed()) {
             std::cerr << "oom score: " << res->oom_score_before << '\n';


### PR DESCRIPTION
### Upon reflection, I don't think this feature is necessary, and maybe not even desirable, because:

1.  When using `mapped_private`, you have to configure  enough (RAM + swap) size for the full configured `chain-state-db-size-mb` (or the `mmap(M_PRIVATE)` fails) and nodeos doesn't start. As a result we will be able to grow the state db and use up to that configured size without any issue. 
As long as the actual state size in actually accessed by transactions is less than the RAM, there shouldn't be any swapping, but if in-use state grow beyond the available RAM, swapping should prevent nodeos being killed by the OOM killer.
2. Matt's testing and comments in this PR show that it is quite difficult to demonstrate that the solution implemented in this PR will reliably prevent the process being killed, and will not activate too early.

So I believe that the solution as implemented in this PR is (1) not necessary, and (2) not provably safe and effective, therefore I am in favor of closing this PR.

Please let me know if there is any disagreement regarding closing this PR, otherwise I'll close it as `not planned` in a few days.

### Original PR  comment 

Part of resolution for Leap #1721.

The Linux kernel assigns and maintains an Out of Memory (OOM) score on a per-process basis, The valid range is from 0 (never kill) to 1000 (always kill), the lower the value is, the lower is the probability the process will be killed.

We track this score for Leap, and when the score gets high, flush the dirty pages of our private mapping to disk, lowering the Leap process OOM score, and thus preventing the system from killing our process. 

Currently, we trigger the flush() for an `oom` value of `980`, which is pretty hard to reach on a system which has more memory than the state database working set (about 20GB for EOS). I tried launching a bunch of programs gobbling memory while `nodeos` was running, but these programs were killed by the OS while `nodeos` continued working happily, even with a lower `oom_score` threshold (I tried `900` and `800`).

This PR makes leap `mapped_private` mode function in a somewhat optimal mode, using as much memory as possible for its chainbase db in order to preventing constant writebacks to disk, while still doing occasional writebacks (to avoid crashing) on systems with limited RAM.