### PR TITLE
Avoid creating dirty pages when rebalancing trees.

### DIFF
--- a/include/chainbase/undo_index.hpp
+++ b/include/chainbase/undo_index.hpp
@@ -114,7 +114,8 @@ namespace chainbase {
          return n->_color;
       }
       static void set_color(node_ptr n, color c) {
-         n->_color = c;
+         if (n->_color != c)
+            n->_color = c;
       }
       static color black() { return 0; }
       static color red() { return 1; }
@@ -124,7 +125,8 @@ namespace chainbase {
          return n->_color;
       }
       static void set_balance(node_ptr n, balance c) {
-         n->_color = c;
+         if (n->_color != c)
+            n->_color = c;
       }
       static balance negative() { return -1; }
       static balance zero() { return 0; }


### PR DESCRIPTION
Every time we insert elements into (or erase from) a boost intrusive rbtree, the tree is rebalanced, which can cause many elements from the tree to be affected, and for each affected element the `_color` member of that element is updated.

In many cases, the color value is the same as it was previously, but even if we write the exact same value as was there already, the page containing this element is marked dirty.

This PR checks that the value is indeed different before writing it to memory, which will reduce the number of pages marked dirty, and ultimately the number of pages that need to be flushed to disk to update the disk db.