### PR TITLE
Remove `revert_to_private_mode()` member which would require `MAP_FIXED` to work reliably.

### DIFF
--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -520,10 +520,6 @@ namespace chainbase {
             _read_only_mode = false;
          }
 
-         void revert_to_private_mode() {
-            _db_file.revert_to_private_mode();
-         }
-
          size_t check_memory_and_flush_if_needed() {
             return _db_file.check_memory_and_flush_if_needed();
          }

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -58,7 +58,6 @@ class pinnable_mapped_file {
       ~pinnable_mapped_file();
 
       segment_manager* get_segment_manager() const { return _segment_manager;}
-      void             revert_to_private_mode();
       size_t           check_memory_and_flush_if_needed();
 
 


### PR DESCRIPTION
The reason I initially added this `revert_to_private_mode()` (so we'd load a snapshot in `mapped` mode, and revert to `mapped_private` mode after the snapshot is loaded), was that I hoped that we would only touch a few pages in normal mapped_private functioning.

The snapshot loading seemed a bad case where all state db pages containing data would be touched.

However, even in normal syncing, most of the pages are dirty after a few minutes, so the remap optimization is not worth it I believe. 

In addition, to work correctly, it would require use the linux specific `mmap(...MAP_FIXED)` api instead of the portable boost interprocess mmap interface.

This PR is just unused code removal.