### PR TITLE
Fix issue with incorrect `database_size` when requesting a smaller `shared_file_size`

### DIFF
--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -134,7 +134,8 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
             std::filesystem::resize_file(_data_file_path, shared_file_size);
          }
          else if(shared_file_size < existing_file_size) {
-             std::cerr << "CHAINBASE: \"" << _database_name << "\" requested size of " << shared_file_size << " is less than "
+            _database_size = existing_file_size;
+            std::cerr << "CHAINBASE: \"" << _database_name << "\" requested size of " << shared_file_size << " is less than "
                 "existing size of " << existing_file_size << ". This database will not be shrunk and will "
                 "remain at " << existing_file_size << '\n';
          }


### PR DESCRIPTION
Resolves #28 .

This makes sure our `_database_size` member tracks the actual size of the file we are mmap'ing into memory.