### PR TITLE
Add dynamic check for pagemap support

### DIFF
--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -216,7 +216,6 @@ private:
 
    bool _close() const {
       if (_pagemap_fd >= 0) {
-         assert(_pagemap_supported);
          ::close(_pagemap_fd);
          _pagemap_fd = -1;
       }

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -163,23 +163,6 @@ private:
       return res;
    }
 
-   // /proc/pid/pagemap. This file lets a userspace process find out which physical frame each virtual page
-   // is mapped to. It contains one 64-bit value for each virtual page, containing the following data
-   // (from fs/proc/task_mmu.c, above pagemap_read):
-   // 
-   // Bits 0-54 page frame number (PFN) if present (note: field is zeroed for non-privileged users)
-   // Bits 0-4 swap type if swapped
-   // Bits 5-54 swap offset if swapped
-   // Bit 55 pte is soft-dirty (see Documentation/admin-guide/mm/soft-dirty.rst)
-   // Bit 56 page exclusively mapped (since 4.2)
-   // Bit 57 pte is uffd-wp write-protected (since 5.13) (see Documentation/admin-guide/mm/userfaultfd.rst)
-   // Bits 58-60 zero
-   // Bit 61 page is file-page or shared-anon (since 3.5)
-   // Bit 62 page swapped
-   // Bit 63 page present
-   //
-   // Here we are just checking bit #55 (the soft-dirty bit).
-   // ----------------------------------------------------------------------------------------------------
    bool _read(uintptr_t vaddr, std::span<uint64_t> dest_uint64) const {
       if (!_open()) // make sure file is open
          return false;

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -49,10 +49,10 @@ public:
 
    // returns true if pagemap *is* supported and we successfully performed `clear_refs`
    bool check_pagemap_support_and_clear_refs() {
-#if defined(__linux__) && defined(__x86_64__)
       if (!_pagemap_support_checked) {
          _pagemap_support_checked = true;
 
+#if defined(__linux__) && defined(__x86_64__)
          fs::path path = fs::temp_directory_path() / "nodeos_pagemap_check";
          if (!fs::exists(path)) {
             std::ofstream ofs(path.generic_string(), std::ofstream::trunc);
@@ -72,8 +72,9 @@ public:
                   _pagemap_supported = true;
             }
          }
-      }
 #endif
+         std::cerr << "CHAINBASE: Detect pagemap support: " <<  (_pagemap_supported ? "OK" : "Not supported") << '\n';
+      }
       return _pagemap_supported;
    }
    


### PR DESCRIPTION
This is to better support systems like Ubuntu running under WSL2, where the kernel may be running without configured pagemap soft-dirty support, as shown by:

```
zcat /proc/config.gz | grep SOFT_DIRTY
CONFIG_HAVE_ARCH_SOFT_DIRTY=y
# CONFIG_MEM_SOFT_DIRTY is not set
```

In this change, after attempting the clear the soft-dirty bits when opening a new chainbase db, we try mapping and modifying a 4K page to verify that the soft-dirty feature is working correctly.

@heifner could you try this branch on your system? I have some problems with my own WSL2/windows environment.