### PR TITLE
[leap 5.0] use `free()` -- not `delete` -- for `aligned_alloc()` pointer

### DIFF
--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -38,7 +38,7 @@ public:
          _pagemap_support_checked = true;
 
 #if defined(__linux__) && defined(__x86_64__)
-         std::unique_ptr<char> p { (char *)std::aligned_alloc(pagesz, pagesz) };
+         std::unique_ptr<char, void(*)(char*)> p { (char *)std::aligned_alloc(pagesz, pagesz), [](char* p) {free(p);} };
 
          if (_clear_refs()) {
             if (!_page_dirty((uintptr_t)p.get())) {

--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -38,7 +38,7 @@ public:
          _pagemap_support_checked = true;
 
 #if defined(__linux__) && defined(__x86_64__)
-         std::unique_ptr<char, void(*)(char*)> p { (char *)std::aligned_alloc(pagesz, pagesz), [](char* p) {free(p);} };
+         std::unique_ptr<char, void(*)(char*)> p { (char *)std::aligned_alloc(pagesz, pagesz), [](char* p) {std::free(p);} };
 
          if (_clear_refs()) {
             if (!_page_dirty((uintptr_t)p.get())) {


### PR DESCRIPTION
`aligned_alloc()` is a C allocator, and memory returned from it should be `free()`ed -- not `delete`ed -- which is what `unique_ptr` will do out of the box. The current code is throwing a warning,
```
/usr/include/c++/13.2.1/bits/unique_ptr.h:99:9: warning: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
/leap/libraries/chainbase/include/chainbase/pagemap_accessor.hpp:41:62: note: returned from ‘void* aligned_alloc(size_t, size_t)’
   41 |          std::unique_ptr<char> p { (char *)std::aligned_alloc(pagesz, pagesz) };
```
but this is also being flagged by ASAN (and leap is otherwise generally clean of ASAN faults).

Since we're seeing this mismatch flagged in multiple manners and it's a low risk & low touch fix, I think we should go ahead and fix it in leap 5.0. But this does mean creation of a new `leap-5.0` branch here in chainbase.

An alternative approach that would be less complex would be to just use a variable on the stack.