### PR TITLE
[leap 5.0 -> main] use `free()` -- not `delete` -- for `aligned_alloc()` pointer

### DIFF
--- a/include/chainbase/pagemap_accessor.hpp
+++ b/include/chainbase/pagemap_accessor.hpp
@@ -38,7 +38,7 @@ public:
          _pagemap_support_checked = true;
 
 #if defined(__linux__) && defined(__x86_64__)
-         std::unique_ptr<char> p { (char *)std::aligned_alloc(pagesz, pagesz) };
+         std::unique_ptr<char, void(*)(char*)> p { (char *)std::aligned_alloc(pagesz, pagesz), [](char* p) {std::free(p);} };
 
          if (_clear_refs()) {
             if (!_page_dirty((uintptr_t)p.get())) {


### PR DESCRIPTION
Merges #32 from the leap-5.0 branch to main.