### PR TITLE
avoid invalid iterator dereference in `get_allocator()`

### DIFF
--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -70,6 +70,8 @@ class pinnable_mapped_file {
       static std::optional<allocator<T>> get_allocator(void *object) {
          if (!_segment_manager_map.empty()) {
             auto it = _segment_manager_map.upper_bound(object);
+            if(it == _segment_manager_map.begin())
+               return {};
             auto [seg_start, seg_end] = *(--it);
             // important: we need to check whether the pointer is really within the segment, as shared objects'
             // can also be created on the stack (in which case the data is actually allocated on the heap using


### PR DESCRIPTION
`get_allocator()` needs to return the bip allocator for a given pointer based on looking up that pointer in a global map of address ranges, or return nullopt_t if the pointer is not within any address range (which means it wasn't allocated in a bip allocator, such as being allocated on stack).

Consider there is a single range registered (`_segment_manager_map.size() == 1`) and this range is from 0x2000 to 0x4000. `get_allocator(0x5000)` will cause `upper_bound()` to return `end()`. Then reversing the iterator by one via `*(--it)` will return the 0x2000-0x4000 entry, the `if (object < seg_end)` check fails, and nullopt_t is returned as expected.

But `get_allocator(0x1000)` will return `begin()`. This causes the `*(--it)` to iterate off the valid range and dereference an invalid iterator.

Add a check for `begin()` and immediately return nullopt_t.