### PR TITLE
[leap5] more CI platform coverage + sanitizers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,20 +9,34 @@ on:
 
 jobs:
   build-test:
-    name: Build & Test
-    runs-on: ubuntu-22.04
+    name: 'Build & Test: ${{matrix.cfg.name}}'
     strategy:
+      fail-fast: false
       matrix:
-        os: ["debian:bullseye", "ubuntu:jammy"]
-    container: ${{matrix.os}}
+        include:
+          - cfg: {name: 'macos',             runson: 'macos-latest'}
+          - cfg: {name: 'gcc10',             runson: 'ubuntu-latest', container: 'debian:bullseye'}
+          - cfg: {name: 'gcc11',             runson: 'ubuntu-latest', container: 'ubuntu:jammy'}
+          - cfg: {name: 'gcc12',             runson: 'ubuntu-latest', container: 'debian:bookworm'}
+          - cfg: {name: 'gcc-arch',          runson: 'ubuntu-latest', container: 'archlinux'}
+          - cfg: {name: 'clang-UBSAN-arch',  runson: 'ubuntu-latest', container: 'archlinux',
+                  cmake: '-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all"'}
+          - cfg: {name: 'clang-ASAN-arch',   runson: 'ubuntu-latest', container: 'archlinux',
+                  cmake: '-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_FLAGS=-fsanitize=address'}
+    runs-on: ${{matrix.cfg.runson}}
+    container: ${{matrix.cfg.container}}
     steps:
-      - name: Install deps
-        run: |
-          apt-get update && apt-get upgrade -y
-          apt-get install -y build-essential cmake libboost-dev libboost-system-dev libboost-test-dev
-      - uses: actions/checkout@v3
-      - name: Build & Test
-        run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-          cmake --build build -- -j $(nproc)
-          cd build && ctest --output-on-failure -j $(nproc)
+      - name: Arch packages
+        if: matrix.cfg.container == 'archlinux'
+        run: pacman --noconfirm -Syu && pacman --noconfirm -S base-devel boost cmake git clang llvm libc++
+      - name: Debian/Ubuntu packages
+        if: startsWith(matrix.cfg.container, 'debian') || startsWith(matrix.cfg.container, 'ubuntu')
+        run: apt-get update && apt-get -y upgrade && apt-get -y install build-essential cmake libboost-all-dev
+      - name: brew packages
+        if: matrix.cfg.name == 'macos'
+        run: brew install boost
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cmake -B build ${{matrix.cfg.cmake}} && cmake --build build -- -j
+      - name: Test
+        run: cd build && ctest --output-on-failure


### PR DESCRIPTION
Adds more coverage in CI including UBSAN & ASAN which would have detected some recent defects.

macos is known failing.

Sending to leap5 branch first so that fixes on that branch can be more thoroughly tested