### PR TITLE
[leap5] in undo tests, create `undo_index` in CB memory segment and remove `removed_nodes_tracker`

### DIFF
--- a/include/chainbase/undo_index.hpp
+++ b/include/chainbase/undo_index.hpp
@@ -415,56 +415,11 @@ namespace chainbase {
             BOOST_THROW_EXCEPTION( std::logic_error{ "could not modify object, most likely a uniqueness constraint was violated" } );
       }
 
-      // Allows testing whether a value has been removed from the undo_index.
-      //
-      // The lifetime of an object removed through a removed_nodes_tracker
-      // does not end before the removed_nodes_tracker is destroyed or invalidated.
-      //
-      // A removed_nodes_tracker is invalidated by the following members of undo_index:
-      // start_undo_session, commit, squash, and undo.
-      class removed_nodes_tracker {
-       public:
-         explicit removed_nodes_tracker(undo_index& idx) : _self(&idx) {}
-         ~removed_nodes_tracker() {
-            _removed_values.clear_and_dispose([this](value_type* obj) { _self->dispose_node(*obj); });
-         }
-         removed_nodes_tracker(const removed_nodes_tracker&) = delete;
-         removed_nodes_tracker& operator=(const removed_nodes_tracker&) = delete;
-         bool is_removed(const value_type& obj) const {
-            return undo_index::get_removed_field(obj) == erased_flag;
-         }
-         // Must be used in place of undo_index::remove
-         void remove(const value_type& obj) {
-            _self->remove(obj, *this);
-         }
-       private:
-         friend class undo_index;
-         void save(value_type& obj) {
-            undo_index::set_removed_field(obj, erased_flag);
-            _removed_values.push_front(obj);
-         }
-         undo_index* _self;
-         list_base<node, index0_type> _removed_values;
-      };
-      auto track_removed() {
-         return removed_nodes_tracker(*this);
-      }
-
       void remove( const value_type& obj ) noexcept {
          auto& node_ref = const_cast<value_type&>(obj);
          erase_impl(node_ref);
          if(on_remove(node_ref)) {
             dispose_node(node_ref);
-         }
-      }
-
-    private:
-
-      void remove( const value_type& obj, removed_nodes_tracker& tracker ) noexcept {
-         auto& node_ref = const_cast<value_type&>(obj);
-         erase_impl(node_ref);
-         if(on_remove(node_ref)) {
-            tracker.save(node_ref);
          }
       }
 

--- a/test/undo_index.cpp
+++ b/test/undo_index.cpp
@@ -9,13 +9,6 @@
 #include <boost/test/data/monomorphic.hpp>
 #include <boost/test/data/test_case.hpp>
 
-// gcc-11 adds new dynamic memory warnings that return false positives for many of the stack allocated instantiations of
-// chainbase::undo_index<>. For example, see test_insert_modify. Evaluation of the actual behavior using ASAN with gcc-11 and
-// clang-11 indicates these are false positives. The warning is disabled for gcc-11 and above.
-#if defined(__GNUC__) && (__GNUC__ >= 11) && !defined(__clang__)
-#  pragma GCC diagnostic ignored "-Wfree-nonheap-object"
-#endif
-
 namespace {
 int exception_counter = 0;
 int throw_at = -1;
@@ -103,6 +96,37 @@ using key = typename key_impl<decltype(Fn)>::template fn<Fn>;
 
 }
 
+template <typename... T>
+struct undo_index_in_segment {
+   using undo_index_t = chainbase::undo_index<T...>;
+
+   template <typename A>
+   undo_index_in_segment(A& alloc) : segment_manager(*alloc.get_segment_manager()) {
+      p = segment_manager.construct<undo_index_t>("")(alloc);
+   }
+
+   ~undo_index_in_segment() {
+      if(p)
+         segment_manager.destroy_ptr(p);
+   }
+
+   undo_index_t* const operator->() {
+      return p;
+   }
+
+   undo_index_t& operator*() {
+      return *p;
+   }
+
+   chainbase::pinnable_mapped_file::segment_manager& segment_manager;
+   undo_index_t* p = nullptr;
+
+   undo_index_in_segment(const undo_index_in_segment&) = delete;
+   undo_index_in_segment(undo_index_in_segment&&) = delete;
+   undo_index_in_segment& operator=(const undo_index_in_segment&) = delete;
+   undo_index_in_segment& operator=(undo_index_in_segment&&) = delete;
+};
+
 BOOST_AUTO_TEST_SUITE(undo_index_tests)
 
 #define EXCEPTION_TEST_CASE(name)                               \
@@ -115,20 +139,20 @@ EXCEPTION_TEST_CASE(test_simple) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<basic_element_t, test_allocator<basic_element_t>,
+      undo_index_in_segment<basic_element_t, test_allocator<basic_element_t>,
                             boost::multi_index::ordered_unique<key<&basic_element_t::id>>> i0(alloc);
-      i0.emplace([](basic_element_t& elem) {});
-      const basic_element_t* element = i0.find(0);
+      i0->emplace([](basic_element_t& elem) {});
+      const basic_element_t* element = i0->find(0);
       BOOST_TEST((element != nullptr && element->id == 0));
-      const basic_element_t* e1 = i0.find(1);
+      const basic_element_t* e1 = i0->find(1);
       BOOST_TEST(e1 == nullptr);
-      i0.emplace([](basic_element_t& elem) {});
-      const basic_element_t* e2 = i0.find(1);
+      i0->emplace([](basic_element_t& elem) {});
+      const basic_element_t* e2 = i0->find(1);
       BOOST_TEST((e2 != nullptr && e2->id == 1));
 
-      i0.modify(*element, [](basic_element_t& elem) {});
-      i0.remove(*element);
-      element = i0.find(0);
+      i0->modify(*element, [](basic_element_t& elem) {});
+      i0->remove(*element);
+      element = i0->find(0);
       BOOST_TEST(element == nullptr);
    } catch ( ... ) {
       fs::remove_all( temp );
@@ -173,19 +197,19 @@ EXCEPTION_TEST_CASE(test_insert_undo) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary> > > i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session = i0.start_undo_session(true);
-         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-         BOOST_TEST(i0.find(1)->secondary == 12);
+         auto undo_checker = capture_state(*i0);
+         auto session = i0->start_undo_session(true);
+         i0->emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0->find(1)->secondary == 12);
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
-      BOOST_TEST(i0.find(1) == nullptr);
+      BOOST_TEST(i0->find(0)->secondary == 42);
+      BOOST_TEST(i0->find(1) == nullptr);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -198,22 +222,22 @@ EXCEPTION_TEST_CASE(test_insert_squash) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary> > > i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session0 = i0.start_undo_session(true);
-         auto session1 = i0.start_undo_session(true);
-         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-         BOOST_TEST(i0.find(1)->secondary == 12);
+         auto undo_checker = capture_state(*i0);
+         auto session0 = i0->start_undo_session(true);
+         auto session1 = i0->start_undo_session(true);
+         i0->emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0->find(1)->secondary == 12);
          session1.squash();
-         BOOST_TEST(i0.find(1)->secondary == 12);
+         BOOST_TEST(i0->find(1)->secondary == 12);
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
-      BOOST_TEST(i0.find(1) == nullptr);
+      BOOST_TEST(i0->find(0)->secondary == 42);
+      BOOST_TEST(i0->find(1) == nullptr);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -225,22 +249,22 @@ EXCEPTION_TEST_CASE(test_insert_push) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary> > > i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session = i0.start_undo_session(true);
-         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-         BOOST_TEST(i0.find(1)->secondary == 12);
+         auto undo_checker = capture_state(*i0);
+         auto session = i0->start_undo_session(true);
+         i0->emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0->find(1)->secondary == 12);
          session.push();
-         i0.commit(i0.revision());
+         i0->commit(i0->revision());
       }
-      BOOST_TEST(!i0.has_undo_session());
-      BOOST_TEST(i0.find(0)->secondary == 42);
-      BOOST_TEST(i0.find(1)->secondary == 12);
+      BOOST_TEST(!i0->has_undo_session());
+      BOOST_TEST(i0->find(0)->secondary == 42);
+      BOOST_TEST(i0->find(1)->secondary == 12);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -253,18 +277,18 @@ EXCEPTION_TEST_CASE(test_modify_undo) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session = i0.start_undo_session(true);
-         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-         BOOST_TEST(i0.find(0)->secondary == 18);
+         auto undo_checker = capture_state(*i0);
+         auto session = i0->start_undo_session(true);
+         i0->modify(*i0->find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0->find(0)->secondary == 18);
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0->find(0)->secondary == 42);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -277,21 +301,21 @@ EXCEPTION_TEST_CASE(test_modify_squash) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session0 = i0.start_undo_session(true);
-         auto session1 = i0.start_undo_session(true);
-         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-         BOOST_TEST(i0.find(0)->secondary == 18);
+         auto undo_checker = capture_state(*i0);
+         auto session0 = i0->start_undo_session(true);
+         auto session1 = i0->start_undo_session(true);
+         i0->modify(*i0->find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0->find(0)->secondary == 18);
          session1.squash();
-         BOOST_TEST(i0.find(0)->secondary == 18);
+         BOOST_TEST(i0->find(0)->secondary == 18);
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0->find(0)->secondary == 42);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -304,21 +328,21 @@ EXCEPTION_TEST_CASE(test_modify_push) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session = i0.start_undo_session(true);
-         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-         BOOST_TEST(i0.find(0)->secondary == 18);
+         auto undo_checker = capture_state(*i0);
+         auto session = i0->start_undo_session(true);
+         i0->modify(*i0->find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0->find(0)->secondary == 18);
          session.push();
-         i0.commit(i0.revision());
+         i0->commit(i0->revision());
       }
-      BOOST_TEST(!i0.has_undo_session());
-      BOOST_TEST(i0.find(0)->secondary == 18);
+      BOOST_TEST(!i0->has_undo_session());
+      BOOST_TEST(i0->find(0)->secondary == 18);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -331,18 +355,18 @@ EXCEPTION_TEST_CASE(test_remove_undo) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session = i0.start_undo_session(true);
-         i0.remove(*i0.find(0));
-         BOOST_TEST(i0.find(0) == nullptr);
+         auto undo_checker = capture_state(*i0);
+         auto session = i0->start_undo_session(true);
+         i0->remove(*i0->find(0));
+         BOOST_TEST(i0->find(0) == nullptr);
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0->find(0)->secondary == 42);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -355,21 +379,21 @@ EXCEPTION_TEST_CASE(test_remove_squash) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session0 = i0.start_undo_session(true);
-         auto session1 = i0.start_undo_session(true);
-         i0.remove(*i0.find(0));
-         BOOST_TEST(i0.find(0) == nullptr);
+         auto undo_checker = capture_state(*i0);
+         auto session0 = i0->start_undo_session(true);
+         auto session1 = i0->start_undo_session(true);
+         i0->remove(*i0->find(0));
+         BOOST_TEST(i0->find(0) == nullptr);
          session1.squash();
-         BOOST_TEST(i0.find(0) == nullptr);
+         BOOST_TEST(i0->find(0) == nullptr);
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0->find(0)->secondary == 42);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -382,21 +406,21 @@ EXCEPTION_TEST_CASE(test_remove_push) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session = i0.start_undo_session(true);
-         i0.remove(*i0.find(0));
-         BOOST_TEST(i0.find(0) == nullptr);
+         auto undo_checker = capture_state(*i0);
+         auto session = i0->start_undo_session(true);
+         i0->remove(*i0->find(0));
+         BOOST_TEST(i0->find(0) == nullptr);
          session.push();
-         i0.commit(i0.revision());
+         i0->commit(i0->revision());
       }
-      BOOST_TEST(!i0.has_undo_session());
-      BOOST_TEST(i0.find(0) == nullptr);
+      BOOST_TEST(!i0->has_undo_session());
+      BOOST_TEST(i0->find(0) == nullptr);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -409,15 +433,15 @@ EXCEPTION_TEST_CASE(test_insert_modify) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-      BOOST_TEST(i0.find(1)->secondary == 12);
-      i0.modify(*i0.find(1), [](test_element_t& elem) { elem.secondary = 24; });
-      BOOST_TEST(i0.find(1)->secondary == 24);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 12; });
+      BOOST_TEST(i0->find(1)->secondary == 12);
+      i0->modify(*i0->find(1), [](test_element_t& elem) { elem.secondary = 24; });
+      BOOST_TEST(i0->find(1)->secondary == 24);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -430,21 +454,21 @@ EXCEPTION_TEST_CASE(test_insert_modify_undo) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session = i0.start_undo_session(true);
-         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-         BOOST_TEST(i0.find(1)->secondary == 12);
-         i0.modify(*i0.find(1), [](test_element_t& elem) { elem.secondary = 24; });
-         BOOST_TEST(i0.find(1)->secondary == 24);
+         auto undo_checker = capture_state(*i0);
+         auto session = i0->start_undo_session(true);
+         i0->emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0->find(1)->secondary == 12);
+         i0->modify(*i0->find(1), [](test_element_t& elem) { elem.secondary = 24; });
+         BOOST_TEST(i0->find(1)->secondary == 24);
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
-      BOOST_TEST(i0.find(1) == nullptr);
+      BOOST_TEST(i0->find(0)->secondary == 42);
+      BOOST_TEST(i0->find(1) == nullptr);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -458,23 +482,23 @@ EXCEPTION_TEST_CASE(test_insert_modify_squash) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session1 = i0.start_undo_session(true);
-         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-         BOOST_TEST(i0.find(1)->secondary == 12);
-         auto session2 = i0.start_undo_session(true);
-         i0.modify(*i0.find(1), [](test_element_t& elem) { elem.secondary = 24; });
-         BOOST_TEST(i0.find(1)->secondary == 24);
+         auto undo_checker = capture_state(*i0);
+         auto session1 = i0->start_undo_session(true);
+         i0->emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0->find(1)->secondary == 12);
+         auto session2 = i0->start_undo_session(true);
+         i0->modify(*i0->find(1), [](test_element_t& elem) { elem.secondary = 24; });
+         BOOST_TEST(i0->find(1)->secondary == 24);
          session2.squash();
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
-      BOOST_TEST(i0.find(1) == nullptr);
+      BOOST_TEST(i0->find(0)->secondary == 42);
+      BOOST_TEST(i0->find(1) == nullptr);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -487,21 +511,21 @@ EXCEPTION_TEST_CASE(test_insert_remove_undo) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session = i0.start_undo_session(true);
-         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-         BOOST_TEST(i0.find(1)->secondary == 12);
-         i0.remove(*i0.find(1));
-         BOOST_TEST(i0.find(1) == nullptr);
+         auto undo_checker = capture_state(*i0);
+         auto session = i0->start_undo_session(true);
+         i0->emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0->find(1)->secondary == 12);
+         i0->remove(*i0->find(1));
+         BOOST_TEST(i0->find(1) == nullptr);
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
-      BOOST_TEST(i0.find(1) == nullptr);
+      BOOST_TEST(i0->find(0)->secondary == 42);
+      BOOST_TEST(i0->find(1) == nullptr);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -514,23 +538,23 @@ EXCEPTION_TEST_CASE(test_insert_remove_squash) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session1 = i0.start_undo_session(true);
-         i0.emplace([](test_element_t& elem) { elem.secondary = 12; });
-         BOOST_TEST(i0.find(1)->secondary == 12);
-         auto session2 = i0.start_undo_session(true);
-         i0.remove(*i0.find(1));
-         BOOST_TEST(i0.find(1) == nullptr);
+         auto undo_checker = capture_state(*i0);
+         auto session1 = i0->start_undo_session(true);
+         i0->emplace([](test_element_t& elem) { elem.secondary = 12; });
+         BOOST_TEST(i0->find(1)->secondary == 12);
+         auto session2 = i0->start_undo_session(true);
+         i0->remove(*i0->find(1));
+         BOOST_TEST(i0->find(1) == nullptr);
          session2.squash();
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
-      BOOST_TEST(i0.find(1) == nullptr);
+      BOOST_TEST(i0->find(0)->secondary == 42);
+      BOOST_TEST(i0->find(1) == nullptr);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -543,20 +567,20 @@ EXCEPTION_TEST_CASE(test_modify_modify_undo) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session = i0.start_undo_session(true);
-         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-         BOOST_TEST(i0.find(0)->secondary == 18);
-         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 24; });
-         BOOST_TEST(i0.find(0)->secondary == 24);
+         auto undo_checker = capture_state(*i0);
+         auto session = i0->start_undo_session(true);
+         i0->modify(*i0->find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0->find(0)->secondary == 18);
+         i0->modify(*i0->find(0), [](test_element_t& elem) { elem.secondary = 24; });
+         BOOST_TEST(i0->find(0)->secondary == 24);
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0->find(0)->secondary == 42);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -569,22 +593,22 @@ EXCEPTION_TEST_CASE(test_modify_modify_squash) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session1 = i0.start_undo_session(true);
-         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-         BOOST_TEST(i0.find(0)->secondary == 18);
-         auto session2 = i0.start_undo_session(true);
-         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 24; });
-         BOOST_TEST(i0.find(0)->secondary == 24);
+         auto undo_checker = capture_state(*i0);
+         auto session1 = i0->start_undo_session(true);
+         i0->modify(*i0->find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0->find(0)->secondary == 18);
+         auto session2 = i0->start_undo_session(true);
+         i0->modify(*i0->find(0), [](test_element_t& elem) { elem.secondary = 24; });
+         BOOST_TEST(i0->find(0)->secondary == 24);
          session2.squash();
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0->find(0)->secondary == 42);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -597,20 +621,20 @@ EXCEPTION_TEST_CASE(test_modify_remove_undo) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session = i0.start_undo_session(true);
-         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-         BOOST_TEST(i0.find(0)->secondary == 18);
-         i0.remove(*i0.find(0));
-         BOOST_TEST(i0.find(0) == nullptr);
+         auto undo_checker = capture_state(*i0);
+         auto session = i0->start_undo_session(true);
+         i0->modify(*i0->find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0->find(0)->secondary == 18);
+         i0->remove(*i0->find(0));
+         BOOST_TEST(i0->find(0) == nullptr);
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0->find(0)->secondary == 42);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -623,22 +647,22 @@ EXCEPTION_TEST_CASE(test_modify_remove_squash) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         auto undo_checker = capture_state(i0);
-         auto session1 = i0.start_undo_session(true);
-         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-         BOOST_TEST(i0.find(0)->secondary == 18);
-         auto session2 = i0.start_undo_session(true);
-         i0.remove(*i0.find(0));
-         BOOST_TEST(i0.find(0) == nullptr);
+         auto undo_checker = capture_state(*i0);
+         auto session1 = i0->start_undo_session(true);
+         i0->modify(*i0->find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0->find(0)->secondary == 18);
+         auto session2 = i0->start_undo_session(true);
+         i0->remove(*i0->find(0));
+         BOOST_TEST(i0->find(0) == nullptr);
          session2.squash();
       }
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      BOOST_TEST(i0->find(0)->secondary == 42);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -651,17 +675,17 @@ EXCEPTION_TEST_CASE(test_squash_one) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
       {
-         i0.modify(*i0.find(0), [](test_element_t& elem) { elem.secondary = 18; });
-         BOOST_TEST(i0.find(0)->secondary == 18);
-         auto session2 = i0.start_undo_session(true);
-         i0.remove(*i0.find(0));
-         BOOST_TEST(i0.find(0) == nullptr);
+         i0->modify(*i0->find(0), [](test_element_t& elem) { elem.secondary = 18; });
+         BOOST_TEST(i0->find(0)->secondary == 18);
+         auto session2 = i0->start_undo_session(true);
+         i0->remove(*i0->find(0));
+         BOOST_TEST(i0->find(0) == nullptr);
          session2.squash();
       }
    } catch ( ... ) {
@@ -676,13 +700,13 @@ EXCEPTION_TEST_CASE(test_insert_non_unique) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.find(0)->secondary == 42);
-      BOOST_CHECK_THROW(i0.emplace([](test_element_t& elem) { elem.secondary = 42; }),  std::exception);
-      BOOST_TEST(i0.find(0)->secondary == 42);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->find(0)->secondary == 42);
+      BOOST_CHECK_THROW(i0->emplace([](test_element_t& elem) { elem.secondary = 42; }),  std::exception);
+      BOOST_TEST(i0->find(0)->secondary == 42);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -705,39 +729,39 @@ EXCEPTION_TEST_CASE(test_modify_conflict) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<conflict_element_t, test_allocator<conflict_element_t>,
+      undo_index_in_segment<conflict_element_t, test_allocator<conflict_element_t>,
                             boost::multi_index::ordered_unique<key<&conflict_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&conflict_element_t::x0>>,
                             boost::multi_index::ordered_unique<key<&conflict_element_t::x1>>,
                             boost::multi_index::ordered_unique<key<&conflict_element_t::x2>>> i0(alloc);
       // insert 3 elements
-      i0.emplace([](conflict_element_t& elem) { elem.x0 = 0; elem.x1 = 10; elem.x2 = 10; });
-      i0.emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 1; elem.x2 = 11; });
-      i0.emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 2; });
+      i0->emplace([](conflict_element_t& elem) { elem.x0 = 0; elem.x1 = 10; elem.x2 = 10; });
+      i0->emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 1; elem.x2 = 11; });
+      i0->emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 2; });
       {
-         auto session = i0.start_undo_session(true);
+         auto session = i0->start_undo_session(true);
          // set them to a different value
-         i0.modify(*i0.find(0), [](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
-         i0.modify(*i0.find(1), [](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
-         i0.modify(*i0.find(2), [](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
+         i0->modify(*i0->find(0), [](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
+         i0->modify(*i0->find(1), [](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
+         i0->modify(*i0->find(2), [](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
          // create a circular conflict with the original values
-         i0.modify(*i0.find(0), [](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 1; elem.x2 = 10; });
-         i0.modify(*i0.find(1), [](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 2; });
-         i0.modify(*i0.find(2), [](conflict_element_t& elem) { elem.x0 = 0; elem.x1 = 12; elem.x2 = 12; });
+         i0->modify(*i0->find(0), [](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 1; elem.x2 = 10; });
+         i0->modify(*i0->find(1), [](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 2; });
+         i0->modify(*i0->find(2), [](conflict_element_t& elem) { elem.x0 = 0; elem.x1 = 12; elem.x2 = 12; });
       }
-      BOOST_TEST(i0.find(0)->x0 == 0);
-      BOOST_TEST(i0.find(1)->x1 == 1);
-      BOOST_TEST(i0.find(2)->x2 == 2);
+      BOOST_TEST(i0->find(0)->x0 == 0);
+      BOOST_TEST(i0->find(1)->x1 == 1);
+      BOOST_TEST(i0->find(2)->x2 == 2);
       // Check lookup in the other indices
-      BOOST_TEST(i0.get<1>().find(0)->x0 == 0);
-      BOOST_TEST(i0.get<1>().find(11)->x0 == 11);
-      BOOST_TEST(i0.get<1>().find(12)->x0 == 12);
-      BOOST_TEST(i0.get<2>().find(10)->x1 == 10);
-      BOOST_TEST(i0.get<2>().find(1)->x1 == 1);
-      BOOST_TEST(i0.get<2>().find(12)->x1 == 12);
-      BOOST_TEST(i0.get<3>().find(10)->x2 == 10);
-      BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
-      BOOST_TEST(i0.get<3>().find(2)->x2 == 2);
+      BOOST_TEST(i0->get<1>().find(0)->x0 == 0);
+      BOOST_TEST(i0->get<1>().find(11)->x0 == 11);
+      BOOST_TEST(i0->get<1>().find(12)->x0 == 12);
+      BOOST_TEST(i0->get<2>().find(10)->x1 == 10);
+      BOOST_TEST(i0->get<2>().find(1)->x1 == 1);
+      BOOST_TEST(i0->get<2>().find(12)->x1 == 12);
+      BOOST_TEST(i0->get<3>().find(10)->x2 == 10);
+      BOOST_TEST(i0->get<3>().find(11)->x2 == 11);
+      BOOST_TEST(i0->get<3>().find(2)->x2 == 2);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -750,33 +774,35 @@ BOOST_DATA_TEST_CASE(test_insert_fail, boost::unit_test::data::make({true, false
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<conflict_element_t, test_allocator<conflict_element_t>,
-                            boost::multi_index::ordered_unique<key<&conflict_element_t::id>>,
-                            boost::multi_index::ordered_unique<key<&conflict_element_t::x0>>,
-                            boost::multi_index::ordered_unique<key<&conflict_element_t::x1>>,
-                            boost::multi_index::ordered_unique<key<&conflict_element_t::x2>>> i0(alloc);
+
+      undo_index_in_segment<conflict_element_t, test_allocator<conflict_element_t>,
+                                                boost::multi_index::ordered_unique<key<&conflict_element_t::id>>,
+                                                boost::multi_index::ordered_unique<key<&conflict_element_t::x0>>,
+                                                boost::multi_index::ordered_unique<key<&conflict_element_t::x1>>,
+                                                boost::multi_index::ordered_unique<key<&conflict_element_t::x2>>> i0(alloc);
+
       // insert 3 elements
-      i0.emplace([](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
-      i0.emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
-      i0.emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
+      i0->emplace([](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
+      i0->emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
+      i0->emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
       {
-         auto session = i0.start_undo_session(true);
+         auto session = i0->start_undo_session(true);
          // Insert a value with a duplicate
-         BOOST_CHECK_THROW(i0.emplace([](conflict_element_t& elem) { elem.x0 = 81; elem.x1 = 11; elem.x2 = 91; }), std::logic_error);
+         BOOST_CHECK_THROW(i0->emplace([](conflict_element_t& elem) { elem.x0 = 81; elem.x1 = 11; elem.x2 = 91; }), std::logic_error);
       }
-      BOOST_TEST(i0.find(0)->x0 == 10);
-      BOOST_TEST(i0.find(1)->x1 == 11);
-      BOOST_TEST(i0.find(2)->x2 == 12);
+      BOOST_TEST(i0->find(0)->x0 == 10);
+      BOOST_TEST(i0->find(1)->x1 == 11);
+      BOOST_TEST(i0->find(2)->x2 == 12);
       // Check lookup in the other indices
-      BOOST_TEST(i0.get<1>().find(10)->x0 == 10);
-      BOOST_TEST(i0.get<1>().find(11)->x0 == 11);
-      BOOST_TEST(i0.get<1>().find(12)->x0 == 12);
-      BOOST_TEST(i0.get<2>().find(10)->x1 == 10);
-      BOOST_TEST(i0.get<2>().find(11)->x1 == 11);
-      BOOST_TEST(i0.get<2>().find(12)->x1 == 12);
-      BOOST_TEST(i0.get<3>().find(10)->x2 == 10);
-      BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
-      BOOST_TEST(i0.get<3>().find(12)->x2 == 12);
+      BOOST_TEST(i0->get<1>().find(10)->x0 == 10);
+      BOOST_TEST(i0->get<1>().find(11)->x0 == 11);
+      BOOST_TEST(i0->get<1>().find(12)->x0 == 12);
+      BOOST_TEST(i0->get<2>().find(10)->x1 == 10);
+      BOOST_TEST(i0->get<2>().find(11)->x1 == 11);
+      BOOST_TEST(i0->get<2>().find(12)->x1 == 12);
+      BOOST_TEST(i0->get<3>().find(10)->x2 == 10);
+      BOOST_TEST(i0->get<3>().find(11)->x2 == 11);
+      BOOST_TEST(i0->get<3>().find(12)->x2 == 12);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -789,38 +815,38 @@ EXCEPTION_TEST_CASE(test_modify_fail) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<conflict_element_t, test_allocator<conflict_element_t>,
+      undo_index_in_segment<conflict_element_t, test_allocator<conflict_element_t>,
                             boost::multi_index::ordered_unique<key<&conflict_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&conflict_element_t::x0>>,
                             boost::multi_index::ordered_unique<key<&conflict_element_t::x1>>,
                             boost::multi_index::ordered_unique<key<&conflict_element_t::x2>>> i0(alloc);
       // insert 3 elements
-      i0.emplace([](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
-      i0.emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
-      i0.emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
+      i0->emplace([](conflict_element_t& elem) { elem.x0 = 10; elem.x1 = 10; elem.x2 = 10; });
+      i0->emplace([](conflict_element_t& elem) { elem.x0 = 11; elem.x1 = 11; elem.x2 = 11; });
+      i0->emplace([](conflict_element_t& elem) { elem.x0 = 12; elem.x1 = 12; elem.x2 = 12; });
       {
-         auto session = i0.start_undo_session(true);
+         auto session = i0->start_undo_session(true);
          // Insert a value with a duplicate
-         i0.emplace([](conflict_element_t& elem) { elem.x0 = 71; elem.x1 = 81; elem.x2 = 91; });
-         BOOST_CHECK_THROW(i0.modify(i0.get(3), [](conflict_element_t& elem) { elem.x0 = 71; elem.x1 = 10; elem.x2 = 91; }), std::logic_error);
+         i0->emplace([](conflict_element_t& elem) { elem.x0 = 71; elem.x1 = 81; elem.x2 = 91; });
+         BOOST_CHECK_THROW(i0->modify(i0->get(3), [](conflict_element_t& elem) { elem.x0 = 71; elem.x1 = 10; elem.x2 = 91; }), std::logic_error);
       }
-      BOOST_TEST(i0.get<0>().size() == 3u);
-      BOOST_TEST(i0.get<1>().size() == 3u);
-      BOOST_TEST(i0.get<2>().size() == 3u);
-      BOOST_TEST(i0.get<3>().size() == 3u);
-      BOOST_TEST(i0.find(0)->x0 == 10);
-      BOOST_TEST(i0.find(1)->x1 == 11);
-      BOOST_TEST(i0.find(2)->x2 == 12);
+      BOOST_TEST(i0->get<0>().size() == 3u);
+      BOOST_TEST(i0->get<1>().size() == 3u);
+      BOOST_TEST(i0->get<2>().size() == 3u);
+      BOOST_TEST(i0->get<3>().size() == 3u);
+      BOOST_TEST(i0->find(0)->x0 == 10);
+      BOOST_TEST(i0->find(1)->x1 == 11);
+      BOOST_TEST(i0->find(2)->x2 == 12);
       // Check lookup in the other indices
-      BOOST_TEST(i0.get<1>().find(10)->x0 == 10);
-      BOOST_TEST(i0.get<1>().find(11)->x0 == 11);
-      BOOST_TEST(i0.get<1>().find(12)->x0 == 12);
-      BOOST_TEST(i0.get<2>().find(10)->x1 == 10);
-      BOOST_TEST(i0.get<2>().find(11)->x1 == 11);
-      BOOST_TEST(i0.get<2>().find(12)->x1 == 12);
-      BOOST_TEST(i0.get<3>().find(10)->x2 == 10);
-      BOOST_TEST(i0.get<3>().find(11)->x2 == 11);
-      BOOST_TEST(i0.get<3>().find(12)->x2 == 12);
+      BOOST_TEST(i0->get<1>().find(10)->x0 == 10);
+      BOOST_TEST(i0->get<1>().find(11)->x0 == 11);
+      BOOST_TEST(i0->get<1>().find(12)->x0 == 12);
+      BOOST_TEST(i0->get<2>().find(10)->x1 == 10);
+      BOOST_TEST(i0->get<2>().find(11)->x1 == 11);
+      BOOST_TEST(i0->get<2>().find(12)->x1 == 12);
+      BOOST_TEST(i0->get<3>().find(10)->x2 == 10);
+      BOOST_TEST(i0->get<3>().find(11)->x2 == 11);
+      BOOST_TEST(i0->get<3>().find(12)->x2 == 12);
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -835,14 +861,14 @@ BOOST_AUTO_TEST_CASE(test_project) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<boost::multi_index::tag<by_secondary>, key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 42; });
-      BOOST_TEST(i0.project<by_secondary>(i0.begin()) == i0.get<by_secondary>().begin());
-      BOOST_TEST(i0.project<by_secondary>(i0.end()) == i0.get<by_secondary>().end());
-      BOOST_TEST(i0.project<1>(i0.begin()) == i0.get<by_secondary>().begin());
-      BOOST_TEST(i0.project<1>(i0.end()) == i0.get<by_secondary>().end());
+      i0->emplace([](test_element_t& elem) { elem.secondary = 42; });
+      BOOST_TEST(i0->project<by_secondary>(i0->begin()) == i0->get<by_secondary>().begin());
+      BOOST_TEST(i0->project<by_secondary>(i0->end()) == i0->get<by_secondary>().end());
+      BOOST_TEST(i0->project<1>(i0->begin()) == i0->get<by_secondary>().begin());
+      BOOST_TEST(i0->project<1>(i0->end()) == i0->get<by_secondary>().end());
    } catch ( ... ) {
       fs::remove_all( temp );
       throw;
@@ -856,15 +882,15 @@ EXCEPTION_TEST_CASE(test_remove_tracking_session) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 20; });
-      auto session = i0.start_undo_session(true);
-      auto tracker = i0.track_removed();
-      i0.emplace([](test_element_t& elem) { elem.secondary = 21; });
-      const test_element_t& elem0 = *i0.find(0);
-      const test_element_t& elem1 = *i0.find(1);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 20; });
+      auto session = i0->start_undo_session(true);
+      auto tracker = i0->track_removed();
+      i0->emplace([](test_element_t& elem) { elem.secondary = 21; });
+      const test_element_t& elem0 = *i0->find(0);
+      const test_element_t& elem1 = *i0->find(1);
       BOOST_CHECK(!tracker.is_removed(elem0));
       BOOST_CHECK(!tracker.is_removed(elem1));
       tracker.remove(elem0);
@@ -884,14 +910,14 @@ EXCEPTION_TEST_CASE(test_remove_tracking_no_session) {
    try {
       chainbase::pinnable_mapped_file db(temp, true, 1024 * 1024, false, chainbase::pinnable_mapped_file::map_mode::mapped);
       test_allocator<basic_element_t> alloc(db.get_segment_manager());
-      chainbase::undo_index<test_element_t, test_allocator<test_element_t>,
+      undo_index_in_segment<test_element_t, test_allocator<test_element_t>,
                             boost::multi_index::ordered_unique<key<&test_element_t::id>>,
                             boost::multi_index::ordered_unique<key<&test_element_t::secondary>>> i0(alloc);
-      i0.emplace([](test_element_t& elem) { elem.secondary = 20; });
-      auto tracker = i0.track_removed();
-      i0.emplace([](test_element_t& elem) { elem.secondary = 21; });
-      const test_element_t& elem0 = *i0.find(0);
-      const test_element_t& elem1 = *i0.find(1);
+      i0->emplace([](test_element_t& elem) { elem.secondary = 20; });
+      auto tracker = i0->track_removed();
+      i0->emplace([](test_element_t& elem) { elem.secondary = 21; });
+      const test_element_t& elem0 = *i0->find(0);
+      const test_element_t& elem1 = *i0->find(1);
       BOOST_CHECK(!tracker.is_removed(elem0));
       BOOST_CHECK(!tracker.is_removed(elem1));
       tracker.remove(elem0);


### PR DESCRIPTION
Creating the `undo_index` on the stack (solely done in the undo tests) ultimately causes the index to contain a mixture of stack allocated and shared-memory allocated objects. Unfortunately I don't have an exact proof of _how_ this happens but debugging through the structure's `node_ptr`s makes it quite clear it's occurring.

On Linux this typically is not a problem because the stack and shared-memory region tend to be very close to each other due to the implementation detail of where the `mmap()` is placed. However, on macOS, `mmap()`s get fulfilled from the "other direction": the stack will be at a high address where the `mmap()` will be placed at a very low address. This breaks the new compressed `node_ptr` structures and causes the test to crash.

It's possible to simulate this on Linux by forcing the chainbase shared memory to be located further away from the stack by gobbling up some VM space early, for example, just this line below and then run a simple test like the `test_insert_fail` will also crash on Linux.
```diff
diff --git a/src/pinnable_mapped_file.cpp b/src/pinnable_mapped_file.cpp
index a78cc6a..6786698 100644
--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -76,6 +76,7 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
    _writable(writable),
    _sharable(mode == mapped)
 {
+   void* wut = mmap(nullptr, 16ull*1024*1024*1024*1024, PROT_NONE, MAP_PRIVATE | MAP_ANON, 0, 0);
    if(shared_file_size % _db_size_multiple_requirement) {
       std::string what_str("Database must be mulitple of " + std::to_string(_db_size_multiple_requirement) + " bytes");
       BOOST_THROW_EXCEPTION(std::system_error(make_error_code(db_error_code::bad_size), what_str));

```

Placing the `undo_index`s in the shared memory region avoids the creation of mixed `node_ptr`s.

Unfortunately there still remains a similar issue in `removed_nodes_tracker`. I was unable to rectify this. But... `removed_nodes_tracker` is only used for a couple tests. I cannot find any harm in simply removing it?

fwiw a run on Leap with this branch is at,
https://github.com/AntelopeIO/leap/actions/runs/7493988034
as more clear evidence the removed code is unused.