### PR TITLE
fix globally registered segment manager end address

### DIFF
--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -224,7 +224,7 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
    }
    std::byte* start = (std::byte*)_segment_manager;
    assert(_segment_manager_map.find(start) == _segment_manager_map.end());
-   _segment_manager_map[start] = start + _database_size;
+   _segment_manager_map[start] = start + _segment_manager->get_size();
 }
 
 void pinnable_mapped_file::setup_copy_on_write_mapping() {


### PR DESCRIPTION
The `segment_manager` isn't created at the beginning of the file, but rather at a `header_size` offset. Thus, the `segment_manager` ends at `start+_database_size-header_size`. Fixing this to the correct end address means an object in the 1024 bytes after the mapped DB file won't mistakenly use the wrong allocator.

Not something I've seen happen nor anything detected by tooling, just something I noticed while in here.