### PR TITLE
[leap5] clear the DB dirty bit if `pinnable_mapped_file` fails to fully start

### DIFF
--- a/include/chainbase/scope_exit.hpp
+++ b/include/chainbase/scope_exit.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <utility>
+#include <exception>
+
+namespace chainbase {
+   template<typename F>
+   struct scope_exit {
+      [[nodiscard]] scope_exit(F&& f) : _f(std::move(f)) {}
+      scope_exit(const scope_exit&) = delete;
+      scope_exit& operator=(const scope_exit&) = delete;
+      ~scope_exit() { if(!_canceled) _f(); }
+      void cancel() { _canceled = true; }
+      F _f;
+      bool _canceled = false;
+   };
+
+   template<typename F>
+   struct scope_fail {
+      scope_fail(F&& f) : _f{static_cast<F&&>(f)}, _exception_count{std::uncaught_exceptions()} {}
+      ~scope_fail() {
+         if(_exception_count != std::uncaught_exceptions()) _f();
+      }
+      F _f;
+      int _exception_count;
+   };
+}

--- a/include/chainbase/undo_index.hpp
+++ b/include/chainbase/undo_index.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chainbase/scope_exit.hpp>
 #include <boost/multi_index_container_fwd.hpp>
 #include <boost/intrusive/set.hpp>
 #include <boost/intrusive/avltree.hpp>
@@ -19,19 +20,6 @@
 #include <sstream>
 
 namespace chainbase {
-
-   template<typename F>
-   struct scope_exit {
-    public:
-      [[nodiscard]] scope_exit(F&& f) : _f(std::move(f)) {}
-      scope_exit(const scope_exit&) = delete;
-      scope_exit& operator=(const scope_exit&) = delete;
-      ~scope_exit() { if(!_canceled) _f(); }
-      void cancel() { _canceled = true; }
-    private:
-      F _f;
-      bool _canceled = false;
-   };
 
    // Adapts multi_index's idea of keys to intrusive
    template<typename KeyExtractor, typename T>

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -164,7 +164,11 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
       set_mapped_file_db_dirty(true);
    }
 
-   auto reset_dirty_on_ctor_fail = scope_fail([&]() {
+   auto reset_on_ctor_fail = scope_fail([&]() {
+      _file_mapped_region = bip::mapped_region();
+      if(_non_file_mapped_mapping && _non_file_mapped_mapping != MAP_FAILED)
+         munmap(_non_file_mapped_mapping, _non_file_mapped_mapping_size);
+
       if(_writable)
          set_mapped_file_db_dirty(false);
       std::erase(_instance_tracker, this);

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -1,6 +1,7 @@
 #include <chainbase/pinnable_mapped_file.hpp>
 #include <chainbase/environment.hpp>
 #include <chainbase/pagemap_accessor.hpp>
+#include <chainbase/scope_exit.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <iostream>
 #include <fstream>
@@ -163,6 +164,12 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
       set_mapped_file_db_dirty(true);
    }
 
+   auto reset_dirty_on_ctor_fail = scope_fail([&]() {
+      if(_writable)
+         set_mapped_file_db_dirty(false);
+      std::erase(_instance_tracker, this);
+   });
+
    if(mode == mapped || mode == mapped_private) {
       if (_writable && !_sharable) {
          // First make sure the db file is not on a ram-based tempfs, as it would be an
@@ -198,26 +205,19 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
          BOOST_THROW_EXCEPTION(std::system_error(make_error_code(db_error_code::aborted)));
       });
 
-      try {
-         setup_non_file_mapping();
-         _file_mapped_region = bip::mapped_region();
-         load_database_file(sig_ios);
+      setup_non_file_mapping();
+      _file_mapped_region = bip::mapped_region();
+      load_database_file(sig_ios);
 
 #ifndef _WIN32
-         if(mode == locked) {
-            if(mlock(_non_file_mapped_mapping, _non_file_mapped_mapping_size)) {
-               std::string what_str("Failed to mlock database \"" + _database_name + "\"");
-               BOOST_THROW_EXCEPTION(std::system_error(make_error_code(db_error_code::no_mlock), what_str));
-            }
-            std::cerr << "CHAINBASE: Database \"" << _database_name << "\" has been successfully locked in memory" << '\n';
+      if(mode == locked) {
+         if(mlock(_non_file_mapped_mapping, _non_file_mapped_mapping_size)) {
+            std::string what_str("Failed to mlock database \"" + _database_name + "\"");
+            BOOST_THROW_EXCEPTION(std::system_error(make_error_code(db_error_code::no_mlock), what_str));
          }
+         std::cerr << "CHAINBASE: Database \"" << _database_name << "\" has been successfully locked in memory" << '\n';
+      }
 #endif
-      }
-      catch(...) {
-         if(_writable)
-            set_mapped_file_db_dirty(false);
-         throw;
-      }
 
       _segment_manager = reinterpret_cast<segment_manager*>((char*)_non_file_mapped_mapping+header_size);
    }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -127,4 +127,21 @@ BOOST_AUTO_TEST_CASE( open_and_create ) {
    BOOST_REQUIRE_EQUAL( new_book.b, copy_new_book.b );
 }
 
+BOOST_AUTO_TEST_CASE( mapped_big_boy ) {
+   temp_directory temp_dir;
+   const auto& temp = temp_dir.path();
+
+   BOOST_REQUIRE_THROW(chainbase::database(temp, database::read_write, 1024ull*1024*1024*1024*4, false, pinnable_mapped_file::map_mode::mapped_private), boost::interprocess::interprocess_exception);
+   chainbase::database(temp, database::read_write, 0, false);
+}
+
+BOOST_AUTO_TEST_CASE( mapped_big_boy_extra ) {
+   temp_directory temp_dir;
+   const auto& temp = temp_dir.path();
+
+   chainbase::database(temp, database::read_write, 1024ull*1024*1024*1024*4, false);
+   BOOST_REQUIRE_THROW(chainbase::database(temp, database::read_write, 0, false, pinnable_mapped_file::map_mode::mapped_private), boost::interprocess::interprocess_exception);
+   chainbase::database(temp, database::read_write, 0, false);
+}
+
 // BOOST_AUTO_TEST_SUITE_END()

--- a/test/undo_index.cpp
+++ b/test/undo_index.cpp
@@ -72,17 +72,9 @@ public:
       return base::allocate(count);
    }
 };
-   
 
-template<typename F>
-struct scope_fail {
-   scope_fail(F&& f) : _f{static_cast<F&&>(f)}, _exception_count{std::uncaught_exceptions()} {}
-   ~scope_fail() {
-      if(_exception_count != std::uncaught_exceptions()) _f();
-   }
-   F _f;
-   int _exception_count;
-};
+
+using chainbase::scope_fail;
 
 struct basic_element_t {
    template<typename C, typename A>


### PR DESCRIPTION
Clear the DB dirty bit if `pinnable_mapped_file` throws during ctor after it has set the bit to dirty. Resolves AntelopeIO/leap#2086