### PR TITLE
[leap5] only run overcommit dependent tests on Linux when overcommit is configured appropriately

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,3 +40,7 @@ jobs:
         run: cmake -B build ${{matrix.cfg.cmake}} && cmake --build build -- -j
       - name: Test
         run: cd build && ctest --output-on-failure
+      # some tests are ignored unless overcommit_memory is allowed
+      - name: Check Linux overcommit_memory settings
+        if: matrix.cfg.runson == 'ubuntu-latest'
+        run: grep -q 0 /proc/sys/vm/overcommit_memory


### PR DESCRIPTION
These newly added tests are only well defined on Linux when `overcommit_memory` is set to 0 or 2[^1]. If `overcommit_memory` is set to 1, or run on platforms that have different semantics here then Linux, they will improperly fail. For example, on macOS it allows this large private mapping and then chainbase just takes eons writing out the entire 4TB (now 6TB in this PR) memory.

So only run these tests on Linux, and only run them when  `overcommit_memory` is 0 or 2.

[^1]: and for both configs, that total system memory is below the threshold that the test uses