### PR TITLE
Update header_id to reflect changes since EOSIODB3

### DIFF
--- a/include/chainbase/environment.hpp
+++ b/include/chainbase/environment.hpp
@@ -5,7 +5,9 @@
 namespace chainbase {
 
 constexpr size_t header_size = 1024;
-constexpr uint64_t header_id = 0x3342444f49534f45ULL; //"EOSIODB3" little endian
+// `CHAINB01` reflects changes since `EOSIODB3`.
+// Spring 1.0 is compatible with `CHAINB01`.
+constexpr uint64_t header_id = 0x3130424e49414843ULL; //"CHAINB01" little endian
 
 struct environment  {
    environment() {


### PR DESCRIPTION
The current `header_id` encoding `EOSIODB3` is used in an earlier version of `Chainbase` that was incorporated into `Leap` 5.0. However, since then changes have been made into the main branch of this repo that make Chainbase incompatible with that prior version; that version of Chainbase should not be used in any patched to `Leap` 5.0 but can be used in newer releases of the Antelope implementation. A new version is required to prevent wrong version of Chainbase from being used.

It was decided to change the version encoding scheme and start withe `CHAINB01`.

Resolves https://github.com/AntelopeIO/chainbase/issues/47