### PR TITLE
Make sure all small allocations (<= 512 bytes) are batched together,

### DIFF
--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -509,6 +509,18 @@ namespace chainbase {
              return get_mutable_index<index_type>().remove( obj );
          }
 
+         template<typename ObjectType>
+         void preallocate( size_t num )
+         {
+#if 1
+             if ( _read_only_mode ) {
+                BOOST_THROW_EXCEPTION( std::logic_error( "attempting to preallocate in read-only mode" ) );
+             }
+             typedef typename get_index_type<ObjectType>::type index_type;
+             get_mutable_index<index_type>().preallocate( num );
+#endif
+         }
+
          template<typename ObjectType, typename Constructor>
          const ObjectType& create( Constructor&& con )
          {

--- a/include/chainbase/chainbase.hpp
+++ b/include/chainbase/chainbase.hpp
@@ -512,13 +512,11 @@ namespace chainbase {
          template<typename ObjectType>
          void preallocate( size_t num )
          {
-#if 1
              if ( _read_only_mode ) {
                 BOOST_THROW_EXCEPTION( std::logic_error( "attempting to preallocate in read-only mode" ) );
              }
              typedef typename get_index_type<ObjectType>::type index_type;
              get_mutable_index<index_type>().preallocate( num );
-#endif
          }
 
          template<typename ObjectType, typename Constructor>

--- a/include/chainbase/chainbase_node_allocator.hpp
+++ b/include/chainbase/chainbase_node_allocator.hpp
@@ -26,9 +26,15 @@ namespace chainbase {
 
       pointer allocate(std::size_t num) {
          if (num == 1) {
-            if (_freelist == nullptr) {
-               get_some(allocation_batch_size);
+            if (_block_start == _block_end && _freelist == nullptr) {
+               get_some(_allocation_batch_size);
             }
+            if (_block_start < _block_end) {
+               pointer result =  pointer{static_cast<T*>(static_cast<void*>(_block_start.get()))};
+               _block_start += sizeof(T);
+               return result;
+            }
+            assert(_freelist != nullptr);
             list_item* result = &*_freelist;
             _freelist = _freelist->_next;
             result->~list_item();
@@ -49,41 +55,40 @@ namespace chainbase {
       }
 
       void preallocate(std::size_t num) {
-         if (num >= 2 * allocation_batch_size)
+         if (num >= 2 * _allocation_batch_size)
             get_some(((num - _freelist_size) + 7) & ~7);
       }
 
       bool operator==(const chainbase_node_allocator& other) const { return this == &other; }
       bool operator!=(const chainbase_node_allocator& other) const { return this != &other; }
       segment_manager* get_segment_manager() const { return _manager.get(); }
-      size_t freelist_memory_usage() const { return _freelist_size * sizeof(T); }
+      size_t freelist_memory_usage() const { return _freelist_size * sizeof(T) + (_block_end - _block_start); }
 
     private:
       template<typename T2, typename S2>
       friend class chainbase_node_allocator;
 
-      void get_some(size_t allocation_batch_size) {
+      void get_some(size_t num_to_alloc) {
          static_assert(sizeof(T) >= sizeof(list_item), "Too small for free list");
          static_assert(sizeof(T) % alignof(list_item) == 0, "Bad alignment for free list");
 
-         char* result = (char*)_manager->allocate(sizeof(T) * allocation_batch_size);
-         _freelist_size += allocation_batch_size;
-         auto old_freelist = _freelist;
-         _freelist = bip::offset_ptr<list_item>{(list_item*)result};
-         for(unsigned i = 0; i < allocation_batch_size-1; ++i) {
-            char* next = result + sizeof(T);
-            new(result) list_item{bip::offset_ptr<list_item>{(list_item*)next}};
-            result = next;
-         }
-         new(result) list_item{old_freelist};
+         _block_start = static_cast<char*>(_manager->allocate(sizeof(T) * num_to_alloc));
+         _block_end   = _block_start + sizeof(T) * num_to_alloc;
+
+         if (_allocation_batch_size < max_allocation_batch_size)
+            _allocation_batch_size *= 2;
       }
 
       struct list_item { bip::offset_ptr<list_item> _next; };
 
-      static constexpr size_t allocation_batch_size = 512;
+      static constexpr size_t max_allocation_batch_size = 512;
+      
+      bip::offset_ptr<char>            _block_start;
+      bip::offset_ptr<char>            _block_end;
+      bip::offset_ptr<list_item>       _freelist{};
       bip::offset_ptr<ss_allocator_t>  _ss_alloc;
       bip::offset_ptr<segment_manager> _manager;
-      bip::offset_ptr<list_item>       _freelist{};
+      size_t                           _allocation_batch_size = 4;
       size_t                           _freelist_size = 0;
    };
 

--- a/include/chainbase/chainbase_node_allocator.hpp
+++ b/include/chainbase/chainbase_node_allocator.hpp
@@ -49,7 +49,7 @@ namespace chainbase {
       }
 
       void preallocate(std::size_t num) {
-         if (num > allocation_batch_size)
+         if (num >= 2 * allocation_batch_size)
             get_some(((num - _freelist_size) + 7) & ~7);
       }
 

--- a/include/chainbase/chainbase_node_allocator.hpp
+++ b/include/chainbase/chainbase_node_allocator.hpp
@@ -88,7 +88,7 @@ namespace chainbase {
       bip::offset_ptr<list_item>       _freelist{};
       bip::offset_ptr<ss_allocator_t>  _ss_alloc;
       bip::offset_ptr<segment_manager> _manager;
-      size_t                           _allocation_batch_size = 4;
+      size_t                           _allocation_batch_size = 32;
       size_t                           _freelist_size = 0;
    };
 

--- a/include/chainbase/chainbase_node_allocator.hpp
+++ b/include/chainbase/chainbase_node_allocator.hpp
@@ -14,14 +14,20 @@ namespace chainbase {
     public:
       using value_type = T;
       using pointer = bip::offset_ptr<T>;
-      chainbase_node_allocator(segment_manager* manager) : _manager{manager} {}
-      chainbase_node_allocator(const chainbase_node_allocator& other) : _manager(other._manager) {}
+
+      chainbase_node_allocator(segment_manager* manager) : _manager{manager} {
+         _ss_alloc = pinnable_mapped_file::get_small_size_allocator((std::byte*)manager);
+      }
+
+      chainbase_node_allocator(const chainbase_node_allocator& other) : chainbase_node_allocator(&*other._manager) {}
+
       template<typename U>
-      chainbase_node_allocator(const chainbase_node_allocator<U, S>& other) : _manager(other._manager) {}
+      chainbase_node_allocator(const chainbase_node_allocator<U, S>& other) : chainbase_node_allocator(&*other._manager) {}
+
       pointer allocate(std::size_t num) {
          if (num == 1) {
             if (_freelist == nullptr) {
-               get_some();
+               get_some(allocation_batch_size);
             }
             list_item* result = &*_freelist;
             _freelist = _freelist->_next;
@@ -29,42 +35,56 @@ namespace chainbase {
             --_freelist_size;
             return pointer{(T*)result};
          } else {
-            return pointer{(T*)_manager->allocate(num*sizeof(T))};
+            return pointer{(T*)&*_ss_alloc->allocate(num*sizeof(T))};
          }
       }
+
       void deallocate(const pointer& p, std::size_t num) {
          if (num == 1) {
             _freelist = new (&*p) list_item{_freelist};
             ++_freelist_size;
          } else {
-            _manager->deallocate(&*p);
+            _ss_alloc->deallocate(ss_allocator_t::pointer((char*)&*p), num*sizeof(T));
          }
       }
+
+      void preallocate(std::size_t num) {
+         if (num > allocation_batch_size)
+            get_some(((num - _freelist_size) + 7) & ~7);
+      }
+
       bool operator==(const chainbase_node_allocator& other) const { return this == &other; }
       bool operator!=(const chainbase_node_allocator& other) const { return this != &other; }
       segment_manager* get_segment_manager() const { return _manager.get(); }
       size_t freelist_memory_usage() const { return _freelist_size * sizeof(T); }
+
     private:
       template<typename T2, typename S2>
       friend class chainbase_node_allocator;
-      void get_some() {
+
+      void get_some(size_t allocation_batch_size) {
          static_assert(sizeof(T) >= sizeof(list_item), "Too small for free list");
          static_assert(sizeof(T) % alignof(list_item) == 0, "Bad alignment for free list");
-         const unsigned allocation_batch_size = 64;
+
          char* result = (char*)_manager->allocate(sizeof(T) * allocation_batch_size);
          _freelist_size += allocation_batch_size;
+         auto old_freelist = _freelist;
          _freelist = bip::offset_ptr<list_item>{(list_item*)result};
          for(unsigned i = 0; i < allocation_batch_size-1; ++i) {
             char* next = result + sizeof(T);
             new(result) list_item{bip::offset_ptr<list_item>{(list_item*)next}};
             result = next;
          }
-         new(result) list_item{nullptr};
+         new(result) list_item{old_freelist};
       }
+
       struct list_item { bip::offset_ptr<list_item> _next; };
+
+      static constexpr size_t allocation_batch_size = 512;
+      bip::offset_ptr<ss_allocator_t>  _ss_alloc;
       bip::offset_ptr<segment_manager> _manager;
-      bip::offset_ptr<list_item> _freelist{};
-      size_t _freelist_size = 0;
+      bip::offset_ptr<list_item>       _freelist{};
+      size_t                           _freelist_size = 0;
    };
 
 }  // namepsace chainbase

--- a/include/chainbase/chainbase_node_allocator.hpp
+++ b/include/chainbase/chainbase_node_allocator.hpp
@@ -56,7 +56,7 @@ namespace chainbase {
 
       void preallocate(std::size_t num) {
          if (num >= 2 * _allocation_batch_size)
-            get_some(((num - _freelist_size) + 7) & ~7);
+            get_some((num + 7) & ~7);
       }
 
       bool operator==(const chainbase_node_allocator& other) const { return this == &other; }

--- a/include/chainbase/environment.hpp
+++ b/include/chainbase/environment.hpp
@@ -5,9 +5,13 @@
 namespace chainbase {
 
 constexpr size_t header_size = 1024;
+
 // `CHAINB01` reflects changes since `EOSIODB3`.
+// `CHAINB02` adds the small size allocator
 // Spring 1.0 is compatible with `CHAINB01`.
-constexpr uint64_t header_id = 0x3130424e49414843ULL; //"CHAINB01" little endian
+// Spring 2.0 is compatible with `CHAINB02`.
+// ---------------------------------------------
+constexpr uint64_t header_id = 0x3230424e49414843ULL; //"CHAINB02" little endian
 
 struct environment  {
    environment() {
@@ -67,10 +71,11 @@ struct environment  {
 } __attribute__ ((packed));
 
 struct db_header  {
-   uint64_t id = header_id;
-   bool dirty = false;
-   environment dbenviron;
-} __attribute__ ((packed));
+   uint64_t               id    = header_id;
+   bool                   dirty = false;
+   bip::offset_ptr<char>  small_size_allocator;
+   environment            dbenviron;
+};
 
 constexpr size_t header_dirty_bit_offset = offsetof(db_header, dirty);
 

--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -138,6 +138,13 @@ class pinnable_mapped_file {
       constexpr static size_t                       _db_size_copy_increment       = 1024*1024*1024; //1GB
 };
 
+// pointer can be to the segment manager, or any object contained within.
+// ---------------------------------------------------------------------
+template <class T>
+auto make_allocator(void* seg_mgr) {
+   return *pinnable_mapped_file::get_allocator<T>(seg_mgr);
+}
+
 std::istream& operator>>(std::istream& in, pinnable_mapped_file::map_mode& runtime);
 std::ostream& operator<<(std::ostream& osm, pinnable_mapped_file::map_mode m);
 

--- a/include/chainbase/shared_cow_string.hpp
+++ b/include/chainbase/shared_cow_string.hpp
@@ -26,7 +26,7 @@ namespace chainbase {
       };
 
     public:
-      using allocator_type = bip::allocator<char, segment_manager>;
+      using allocator_type = allocator<char>;
       using iterator       = const char*;
       using const_iterator = const char*;
 

--- a/include/chainbase/shared_cow_vector.hpp
+++ b/include/chainbase/shared_cow_vector.hpp
@@ -23,7 +23,7 @@ namespace chainbase {
       };
 
    public:
-      using allocator_type = bip::allocator<char, segment_manager>;
+      using allocator_type = allocator<char>;
       using iterator       = const T*;      // const because of copy-on-write
       using const_iterator = const T*;
       using value_type     = T;

--- a/include/chainbase/small_size_allocator.hpp
+++ b/include/chainbase/small_size_allocator.hpp
@@ -16,17 +16,21 @@ namespace detail {
 
 template <class backing_allocator, std::size_t sz>
 class allocator {
+public:
    backing_allocator& _back_alloc;
 
-   allocator(backing_allocator& back_alloc) :
-      _back_alloc(back_alloc) {
+   allocator(backing_allocator* back_alloc) :
+      _back_alloc(*back_alloc) {
    }
 
-public:
    using pointer = backing_allocator::pointer;
 
    pointer allocate();
+   
    void deallocate(pointer p);
+
+private:
+   std::mutex _m;  // must be thread-safe
 };
 
 } // namespace detail
@@ -36,6 +40,7 @@ public:
 //          -------------------------------------------------------
 //
 //  All pointers used are of type `backing_allocator::pointer`
+//  allocate/deallocate specify size in bytes.
 // ---------------------------------------------------------------------------------------
 template <class backing_allocator, size_t num_allocators = 64, size_t size_increment = 8> 
 class small_size_allocator {
@@ -43,45 +48,47 @@ public:
    using pointer = backing_allocator::pointer;
 
 private:
+   template <std::size_t... I>
+   static constexpr auto make_alloc_tuple(backing_allocator* back_alloc, std::index_sequence<I...>) {
+      return std::tuple{new detail::allocator<backing_allocator, (I + 1) * size_increment>(back_alloc)...};
+   }
+
+   static_assert(sizeof(typename backing_allocator::value_type) == 1, "backing_allocator should be allocating bytes");
+   
    static constexpr size_t _mask = size_increment - 1;
    
-   using alloc_tuple_t = decltype(make_slab_helper(1, std::make_index_sequence<num_allocators>{}));
+   using alloc_tuple_t = decltype(make_alloc_tuple(nullptr, std::make_index_sequence<num_allocators>{}));
    using alloc_fn_t    = std::function<pointer()>;
    using dealloc_fn_t  = std::function<void(const pointer&)>;
 
+   backing_allocator                        _back_alloc;
    alloc_tuple_t                            _allocators;
    std::array<alloc_fn_t, num_allocators>   _alloc_functions;  // using arrays of functions for fast access
    std::array<dealloc_fn_t, num_allocators> _dealloc_functions;
-   backing_allocator&                       _back_alloc;
 
 public:
    static constexpr size_t max_size = num_allocators * size_increment;
 
-   small_size_allocator(backing_allocator& back_alloc)
-      : _allocators(       make_alloc_tuple(back_alloc, std::make_index_sequence<num_allocators>{}))
+   small_size_allocator(backing_allocator back_alloc)
+      : _back_alloc(std::move(back_alloc))
+      , _allocators(       make_alloc_tuple(&_back_alloc, std::make_index_sequence<num_allocators>{}))
       , _alloc_functions(  make_alloc_fn_array(std::make_index_sequence<num_allocators>{}))
       , _dealloc_functions(make_dealloc_fn_array(std::make_index_sequence<num_allocators>{}))
-      , _back_alloc(back_alloc)
    {}
 
    pointer allocate(std::size_t sz) {
-      if (sz <= max_size)
+      if (0 && sz <= max_size)
          return _alloc_functions[allocator_index(sz)]();
-      return _back_alloc.allocate(sz);
+      return _back_alloc->allocate(sz);
    }
 
-   void deallocate(const pointer &p, std::size_t sz) {
-      if (sz <= max_size)
+   void deallocate(const pointer& p, std::size_t sz) {
+      if (0 && sz <= max_size)
          _dealloc_functions[allocator_index(sz)](p);
-      _back_alloc.deallocate(p, sz);
+      _back_alloc->deallocate(p, sz);
    }
 
 private:
-   template <std::size_t... I>
-   static constexpr auto make_alloc_tuple(backing_allocator& back_alloc, std::index_sequence<I...>) {
-      return std::tuple{new detail::allocator<backing_allocator, (I + 1) * size_increment>(back_alloc)...};
-   }
-
    template <std::size_t... I>
    constexpr auto make_alloc_fn_array(std::index_sequence<I...>) {
       return std::array{std::function{[&allocator = std::get<I>(_allocators)] { return allocator->allocate(); }}...};
@@ -89,10 +96,38 @@ private:
 
    template <std::size_t... I>
    constexpr auto make_dealloc_fn_array(std::index_sequence<I...>) {
-      return std::array{std::function{[&allocator = std::get<I>(_allocators)](pointer p) { allocator->deallocate(p); }}...};
+      return std::array{std::function{[&allocator = std::get<I>(_allocators)](const pointer& p) { allocator->deallocate(p); }}...};
    }
 
    static constexpr size_t allocator_index(size_t sz) { return (sz + _mask) & ~_mask; }
+};
+
+// ---------------------------------------------------------------------------------------
+//          Object allocator
+//          ----------------
+//
+//  emulates the API of `bip::allocator<T, segment_manager>`
+// ---------------------------------------------------------------------------------------
+template<typename T, class backing_allocator>
+class object_allocator {
+public:
+   using pointer = backing_allocator::pointer;
+   
+   object_allocator(backing_allocator* back_alloc) :_back_alloc(back_alloc) {
+   }
+
+   pointer allocate(std::size_t count) {
+      return _back_alloc->allocate(count*sizeof(T));
+   }
+
+   void deallocate(const pointer& p, std::size_t count) {
+      return _back_alloc->deallocate(p, count*sizeof(T));
+   }
+
+   bool operator==(const object_allocator&) const = default;
+   
+private:
+   backing_allocator* _back_alloc; // allocates by size in bytes
 };
 
 } // namespace chainbase

--- a/include/chainbase/small_size_allocator.hpp
+++ b/include/chainbase/small_size_allocator.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+#include <string>
+#include <functional>
+#include <mutex>
+
+namespace chainbase {
+
+namespace detail {
+
+template <class backing_allocator, std::size_t sz>
+class allocator {
+   backing_allocator& _back_alloc;
+
+   allocator(backing_allocator& back_alloc) :
+      _back_alloc(back_alloc) {
+   }
+
+public:
+   using pointer = backing_allocator::pointer;
+
+   pointer allocate();
+   void deallocate(pointer p);
+};
+
+} // namespace detail
+
+// ---------------------------------------------------------------------------------------
+//          An array of 64 allocators for sizes from 8 to 512 bytes
+//          -------------------------------------------------------
+//
+//  All pointers used are of type `backing_allocator::pointer`
+// ---------------------------------------------------------------------------------------
+template <class backing_allocator, size_t num_allocators = 64, size_t size_increment = 8> 
+class small_size_allocator {
+public:
+   using pointer = backing_allocator::pointer;
+
+private:
+   static constexpr size_t _mask = size_increment - 1;
+   
+   using alloc_tuple_t = decltype(make_slab_helper(1, std::make_index_sequence<num_allocators>{}));
+   using alloc_fn_t    = std::function<pointer()>;
+   using dealloc_fn_t  = std::function<void(const pointer&)>;
+
+   alloc_tuple_t                            _allocators;
+   std::array<alloc_fn_t, num_allocators>   _alloc_functions;  // using arrays of functions for fast access
+   std::array<dealloc_fn_t, num_allocators> _dealloc_functions;
+   backing_allocator&                       _back_alloc;
+
+public:
+   static constexpr size_t max_size = num_allocators * size_increment;
+
+   small_size_allocator(backing_allocator& back_alloc)
+      : _allocators(       make_alloc_tuple(back_alloc, std::make_index_sequence<num_allocators>{}))
+      , _alloc_functions(  make_alloc_fn_array(std::make_index_sequence<num_allocators>{}))
+      , _dealloc_functions(make_dealloc_fn_array(std::make_index_sequence<num_allocators>{}))
+      , _back_alloc(back_alloc)
+   {}
+
+   pointer allocate(std::size_t sz) {
+      if (sz <= max_size)
+         return _alloc_functions[allocator_index(sz)]();
+      return _back_alloc.allocate(sz);
+   }
+
+   void deallocate(const pointer &p, std::size_t sz) {
+      if (sz <= max_size)
+         _dealloc_functions[allocator_index(sz)](p);
+      _back_alloc.deallocate(p, sz);
+   }
+
+private:
+   template <std::size_t... I>
+   static constexpr auto make_alloc_tuple(backing_allocator& back_alloc, std::index_sequence<I...>) {
+      return std::tuple{new detail::allocator<backing_allocator, (I + 1) * size_increment>(back_alloc)...};
+   }
+
+   template <std::size_t... I>
+   constexpr auto make_alloc_fn_array(std::index_sequence<I...>) {
+      return std::array{std::function{[&allocator = std::get<I>(_allocators)] { return allocator->allocate(); }}...};
+   }
+
+   template <std::size_t... I>
+   constexpr auto make_dealloc_fn_array(std::index_sequence<I...>) {
+      return std::array{std::function{[&allocator = std::get<I>(_allocators)](pointer p) { allocator->deallocate(p); }}...};
+   }
+
+   static constexpr size_t allocator_index(size_t sz) { return (sz + _mask) & ~_mask; }
+};
+
+} // namespace chainbase

--- a/include/chainbase/small_size_allocator.hpp
+++ b/include/chainbase/small_size_allocator.hpp
@@ -27,13 +27,14 @@ public:
 
    pointer allocate();
    
-   void deallocate(pointer p);
+   void deallocate(const pointer& p);
 
 private:
    std::mutex _m;  // must be thread-safe
 };
 
 } // namespace detail
+
 
 // ---------------------------------------------------------------------------------------
 //          An array of 64 allocators for sizes from 8 to 512 bytes
@@ -61,7 +62,10 @@ private:
    using alloc_fn_t    = std::function<pointer()>;
    using dealloc_fn_t  = std::function<void(const pointer&)>;
 
+   // we store a constructed `bip::allocator` in _back_alloc
+   // all `bip::allocator` constructed from the same `segment_manager` are equivalent
    backing_allocator                        _back_alloc;
+   
    alloc_tuple_t                            _allocators;
    std::array<alloc_fn_t, num_allocators>   _alloc_functions;  // using arrays of functions for fast access
    std::array<dealloc_fn_t, num_allocators> _dealloc_functions;
@@ -76,16 +80,16 @@ public:
       , _dealloc_functions(make_dealloc_fn_array(std::make_index_sequence<num_allocators>{}))
    {}
 
-   pointer allocate(std::size_t sz) {
-      if (0 && sz <= max_size)
-         return _alloc_functions[allocator_index(sz)]();
-      return _back_alloc->allocate(sz);
+   pointer allocate(std::size_t sz_in_bytes) {
+      if (0 && sz_in_bytes <= max_size)
+         return _alloc_functions[allocator_index(sz_in_bytes)]();
+      return _back_alloc.allocate(sz_in_bytes);
    }
 
-   void deallocate(const pointer& p, std::size_t sz) {
-      if (0 && sz <= max_size)
-         _dealloc_functions[allocator_index(sz)](p);
-      _back_alloc->deallocate(p, sz);
+   void deallocate(const pointer& p, std::size_t sz_in_bytes) {
+      if (0 && sz_in_bytes <= max_size)
+         _dealloc_functions[allocator_index(sz_in_bytes)](p);
+      _back_alloc.deallocate(p, sz_in_bytes);
    }
 
 private:
@@ -99,8 +103,9 @@ private:
       return std::array{std::function{[&allocator = std::get<I>(_allocators)](const pointer& p) { allocator->deallocate(p); }}...};
    }
 
-   static constexpr size_t allocator_index(size_t sz) { return (sz + _mask) & ~_mask; }
+   static constexpr size_t allocator_index(size_t sz_in_bytes) { return (sz_in_bytes + _mask) & ~_mask; }
 };
+
 
 // ---------------------------------------------------------------------------------------
 //          Object allocator
@@ -112,16 +117,17 @@ template<typename T, class backing_allocator>
 class object_allocator {
 public:
    using pointer = backing_allocator::pointer;
+   using value_type = T;
    
    object_allocator(backing_allocator* back_alloc) :_back_alloc(back_alloc) {
    }
 
-   pointer allocate(std::size_t count) {
-      return _back_alloc->allocate(count*sizeof(T));
+   pointer allocate(std::size_t num_objects) {
+      return _back_alloc->allocate(num_objects * sizeof(T));
    }
 
-   void deallocate(const pointer& p, std::size_t count) {
-      return _back_alloc->deallocate(p, count*sizeof(T));
+   void deallocate(const pointer& p, std::size_t num_objects) {
+      return _back_alloc->deallocate(p, num_objects * sizeof(T));
    }
 
    bool operator==(const object_allocator&) const = default;

--- a/include/chainbase/small_size_allocator.hpp
+++ b/include/chainbase/small_size_allocator.hpp
@@ -90,7 +90,7 @@ private:
    bip::offset_ptr<char>      _block_start;
    bip::offset_ptr<char>      _block_end;
    backing_allocator          _back_alloc;
-   size_t                     _allocation_batch_size = 4;
+   size_t                     _allocation_batch_size = 32;
    size_t                     _freelist_size         = 0;
    size_t                     _num_blocks_allocated  = 0; // number of blocks allocated from boost segment allocator
    mutable std::mutex         _m;

--- a/include/chainbase/small_size_allocator.hpp
+++ b/include/chainbase/small_size_allocator.hpp
@@ -68,7 +68,7 @@ public:
 
 private:
    struct list_item { bip::offset_ptr<list_item> _next; };
-   static constexpr size_t allocation_batch_size = 128;
+   static constexpr size_t allocation_batch_size = 512;
 
    void get_some() {
       static_assert(sizeof(T) >= sizeof(list_item), "Too small for free list");

--- a/include/chainbase/small_size_allocator.hpp
+++ b/include/chainbase/small_size_allocator.hpp
@@ -133,7 +133,7 @@ private:
    }
 
 public:
-   small_size_allocator(backing_allocator back_alloc)
+   explicit small_size_allocator(backing_allocator back_alloc)
       : _back_alloc(std::move(back_alloc))
       , _allocators(make_allocators(back_alloc, std::make_index_sequence<num_allocators>{})) {}
 
@@ -186,7 +186,7 @@ public:
    using pointer      = char_pointer::template rebind<T>;
    using value_type   = T;
 
-   object_allocator(backing_allocator* back_alloc) :_back_alloc(back_alloc) {
+   explicit object_allocator(backing_allocator* back_alloc) :_back_alloc(back_alloc) {
    }
 
    pointer allocate(std::size_t num_objects) {

--- a/include/chainbase/small_size_allocator.hpp
+++ b/include/chainbase/small_size_allocator.hpp
@@ -100,8 +100,8 @@ private:
 
 
 // ---------------------------------------------------------------------------------------
-//          An array of 64 allocators for sizes from 8 to 512 bytes
-//          -------------------------------------------------------
+//          An array of 128 allocators for sizes from 8 to 1024 bytes
+//          ---------------------------------------------------------
 //
 //  - All pointers used are of type `backing_allocator::pointer`
 //  - allocate/deallocate specify size in bytes.
@@ -172,12 +172,12 @@ public:
 //
 //  emulates the API of `bip::allocator<T, segment_manager>`
 //  backing_allocator is normally the `small_size_allocator`, in which case:
-// - If the allocation size (num_objects * sizeof(T)) is less than 512 bytes, it will be routed
+// - If the allocation size (num_objects * sizeof(T)) is less than 1024 bytes, it will be routed
 //   through the small size allocator which allocates in batch from the `segment_manager`.
-// - If the allocation size (num_objects * sizeof(T)) is greater than 512 bytes, the allocator
+// - If the allocation size (num_objects * sizeof(T)) is greater than 1024 bytes, the allocator
 //   will allocate directly from the segment manager.
-// - the 512 bytes limit is derived from the template parameters of `small_size_allocator`
-//   (size_t num_allocators = 64, size_t size_increment = 8)
+// - the 1024 bytes limit is derived from the template parameters of `small_size_allocator`
+//   (size_t num_allocators = 128, size_t size_increment = 8)
 // ---------------------------------------------------------------------------------------
 template<typename T, class backing_allocator>
 class object_allocator {

--- a/include/chainbase/undo_index.hpp
+++ b/include/chainbase/undo_index.hpp
@@ -350,9 +350,7 @@ namespace chainbase {
       };
 
       void preallocate( std::size_t num ) {
-#if 1
          _allocator.preallocate(num);
-#endif
       }
 
       // Exception safety: strong

--- a/include/chainbase/undo_index.hpp
+++ b/include/chainbase/undo_index.hpp
@@ -694,26 +694,9 @@ namespace chainbase {
       template<int N = 0>
       bool insert_impl(value_type& p) {
          if constexpr (N < sizeof...(Indices)) {
-#if 0
-            auto& index = std::get<N>(_indices);
-            using index_t = std::decay_t<decltype(index)>;
-            std::pair<typename index_t::iterator, bool> pair;
-            constexpr bool has_insert_hint = requires(index_t& index, value_type& p) {
-               index.insert_unique(index.end(), p);
-            };
-            if constexpr (false && N == 1 && has_insert_hint) {
-               pair.first = index.insert_unique(index.end(), p);
-               pair.second = true;
-            } else {
-               pair = index.insert_unique(p);
-            }
-            if(!pair.second) return false;
-            auto guard = scope_exit{[&index,iter=pair.first]{ index.erase(iter); }};
-#else
             auto [iter, inserted] = std::get<N>(_indices).insert_unique(p);
             if(!inserted) return false;
             auto guard = scope_exit{[this,iter=iter]{ std::get<N>(_indices).erase(iter); }};
-#endif
             if(insert_impl<N+1>(p)) {
                guard.cancel();
                return true;

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -330,8 +330,8 @@ void pinnable_mapped_file::setup_non_file_mapping() {
       _non_file_mapped_mapping_size = (_non_file_mapped_mapping_size + (r-1u))/r*r;
    };
 
-   const unsigned _1gb = 1u<<30u;
-   const unsigned _2mb = 1u<<21u;
+   [[maybe_unused]] const unsigned _1gb = 1u<<30u;
+   [[maybe_unused]] const unsigned _2mb = 1u<<21u;
 
 #if defined(MAP_HUGETLB) && defined(MAP_HUGE_1GB)
    _non_file_mapped_mapping = mmap(NULL, _non_file_mapped_mapping_size, PROT_READ|PROT_WRITE, common_map_opts|MAP_HUGETLB|MAP_HUGE_1GB, -1, 0);

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -263,7 +263,7 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
 
 ss_allocator_t* pinnable_mapped_file::get_small_size_allocator(std::byte* seg_mgr) {
    db_header* header = reinterpret_cast<db_header*>(seg_mgr - header_size);
-   return (ss_allocator_t*)&*header->small_size_allocator;
+   return header->small_size_allocator ? (ss_allocator_t*)&*header->small_size_allocator : nullptr;
 }
 
 void pinnable_mapped_file::setup_copy_on_write_mapping() {

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -254,6 +254,7 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
 
    ss_allocator_t* ss_alloc = get_small_size_allocator(start); // relies on `_segment_manager` being initialized
    if (!ss_alloc && _writable) {
+      // create the unique `small_size_allocator` for this `segment_manager`
       db_header* header = reinterpret_cast<db_header*>(start - header_size);
       header->small_size_allocator = (char *)make_small_size_allocator<byte_segment_allocator_t>(_segment_manager);
    }

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -251,7 +251,10 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
    }
    std::byte* start = (std::byte*)_segment_manager;
    assert(_segment_manager_map.find(start) == _segment_manager_map.end());
-   _segment_manager_map[start] = start + _segment_manager->get_size();
+
+   byte_segment_allocator byte_allocator(_segment_manager);
+   _segment_manager_map[start] = seg_info_t{start + _segment_manager->get_size(),
+                                            new ss_allocator(byte_allocator)};
 }
 
 void pinnable_mapped_file::setup_copy_on_write_mapping() {

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -252,9 +252,8 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
    std::byte* start = (std::byte*)_segment_manager;
    assert(_segment_manager_map.find(start) == _segment_manager_map.end());
 
-   byte_segment_allocator byte_allocator(_segment_manager);
    _segment_manager_map[start] = seg_info_t{start + _segment_manager->get_size(),
-                                            new ss_allocator(byte_allocator)};
+                                            make_small_size_allocator<byte_segment_allocator_t>(_segment_manager)};
 }
 
 void pinnable_mapped_file::setup_copy_on_write_mapping() {

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -252,8 +252,10 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
    std::byte* start = (std::byte*)_segment_manager;
    assert(_segment_manager_map.find(start) == _segment_manager_map.end());
 
-   _segment_manager_map[start] = seg_info_t{start + _segment_manager->get_size(),
-                                            make_small_size_allocator<byte_segment_allocator_t>(_segment_manager)};
+   _segment_manager_map[start] =
+   seg_info_t{start + _segment_manager->get_size(),
+              _writable
+              ? make_small_size_allocator<byte_segment_allocator_t>(_segment_manager) : nullptr };
 }
 
 void pinnable_mapped_file::setup_copy_on_write_mapping() {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -494,7 +494,9 @@ BOOST_AUTO_TEST_CASE(shared_vector_apis_segment_alloc) {
 
    // make sure we didn't leak memory
    // -------------------------------
-   BOOST_REQUIRE_EQUAL(free_memory, pmf.get_segment_manager()->get_free_memory());
+   auto ss_alloc = pinnable_mapped_file::get_small_size_allocator((std::byte*)pmf.get_segment_manager());
+   BOOST_REQUIRE_EQUAL(free_memory, pmf.get_segment_manager()->get_free_memory() + ss_alloc->freelist_memory_usage() +
+                                       ss_alloc->memory_overhead());
 }
 
 // -----------------------------------------------------------------------------

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -497,7 +497,6 @@ BOOST_AUTO_TEST_CASE(shared_vector_apis_segment_alloc) {
    auto ss_alloc = pinnable_mapped_file::get_small_size_allocator((std::byte*)pmf.get_segment_manager());
    auto num_blocks_allocated = ss_alloc->num_blocks_allocated();
    auto lost = free_memory - (seg_mgr->get_free_memory() + ss_alloc->freelist_memory_usage());
-   std::cerr << "free_memory=" << free_memory << ", new_free_memory=" << (seg_mgr->get_free_memory() + ss_alloc->freelist_memory_usage()) << ", num_blocks_allocated=" << num_blocks_allocated << '\n';
 
    // for every block allocated from the shared memory segment, we have an overhead of 8 or 16 bytes
    BOOST_REQUIRE(lost == num_blocks_allocated * 8 || lost == num_blocks_allocated * 16);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -495,8 +495,12 @@ BOOST_AUTO_TEST_CASE(shared_vector_apis_segment_alloc) {
    // make sure we didn't leak memory
    // -------------------------------
    auto ss_alloc = pinnable_mapped_file::get_small_size_allocator((std::byte*)pmf.get_segment_manager());
-   BOOST_REQUIRE_EQUAL(free_memory, pmf.get_segment_manager()->get_free_memory() + ss_alloc->freelist_memory_usage() +
-                                       ss_alloc->memory_overhead());
+   auto num_blocks_allocated = ss_alloc->num_blocks_allocated();
+   auto lost = free_memory - (seg_mgr->get_free_memory() + ss_alloc->freelist_memory_usage());
+   std::cerr << "free_memory=" << free_memory << ", new_free_memory=" << (seg_mgr->get_free_memory() + ss_alloc->freelist_memory_usage()) << ", num_blocks_allocated=" << num_blocks_allocated << '\n';
+
+   // for every block allocated from the shared memory segment, we have an overhead of 8 or 16 bytes
+   BOOST_REQUIRE(lost == num_blocks_allocated * 8 || lost == num_blocks_allocated * 16);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Resolves #58.

Currently, many nodeos allocations hit the segment manager, which is costly both in time (involves updating a `rbtree` and rebalancing it) and in space overhead (16 to 40 bytes depending on the size allocated).

This PR adds a small size allocator, which internally maintains 64 free lists (for allocation sizes from `8` to `512` bytes, increment = `8` bytes). The first allocation allocates `512` units (so `511` remain of the free list), reducing the hits of the segment manager allocator by a factor of 512x.

Also, the chainbase `node allocator`, which also does batch allocations for `undo_index` tree nodes, is also using the small size allocator when allocating more than one value to be pushed into the `undo_stack` deque.

#### preallocate

Some tables loaded from the snapshot have a very large number of rows (I saw one with 95 million rows). I thought that instead of allocating by batches of 512 tree nodes, it might be faster to allocate for the 95 million rows in one allocation, which is what I tried with the [preallocate](https://github.com/AntelopeIO/chainbase/blob/a0797d2be1f4021dee2fdfed4e622ad9cc292dfe/include/chainbase/chainbase.hpp#L512-L520). 

However my testing didn't show any significant difference, so the call to `preallocate` is commented out in `controller.cpp`. I have left the implementation in case we want to experiment further later.

#### batch size, number of allocators.

When experimenting with the batch size for allocations, it was clear that larger batch sizes provide better performance when loading the snapshot. The same goes with the number of allocators, and 128 allocators (allowing to batch allocations up to 1024 bytes) perform better than 64 allocators (allowing to batch allocations up to 512 bytes).

However, with 128 allocators, and a batch size of 512, some tests fail because the configuration of the chainbase memory segment in the test is too small.

So I added some code that grows the allocation batch size from 32 to 512.:

https://github.com/AntelopeIO/chainbase/blob/a0797d2be1f4021dee2fdfed4e622ad9cc292dfe/include/chainbase/small_size_allocator.hpp#L84-L85

I should note that I originally started at 4 (instead of the current 32), but my testing showed a slowdown compared to using 32 (which I found somewhat surprising).

#### Why keep the `chainbase_node_allocator`

The `chainbase_node_allocator` still has some benefits:

- it allocates the exact size required for the node
- it doesn't need mutex protection (unlike the `small_size_allocator` which is used from multiple threads when loading the snapshot). 

#### Why not link into the free list in `get_some`?

My experimentation show that not linking newly allocated blocks into the free list is faster (even though the code in `allocate()` is slightly longer):

https://github.com/AntelopeIO/chainbase/blob/a0797d2be1f4021dee2fdfed4e622ad9cc292dfe/include/chainbase/chainbase_node_allocator.hpp#L71-L80
