### PR TITLE
resolve two cmake warnings with latest cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Defines ChainBase library target.
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.12 )
 project( ChainBase )
 
 #list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ IF( WIN32 )
 ENDIF(WIN32)
 
 if(NOT TARGET Boost::unit_test_framework)
+   if(POLICY CMP0167)
+      cmake_policy(SET CMP0167 NEW)
+   endif()
    FIND_PACKAGE(Boost 1.67 REQUIRED COMPONENTS system unit_test_framework)
 endif()
 


### PR DESCRIPTION
cmake 3.31 has deprecated rules for <3.10 resulting in a warning (even as part of spring),
```
CMake Deprecation Warning at CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```
cmake 3.12 is required for c++20 anyways, so bump minimum to 3.12.

I also noticed when building chainbase standalone (not as part of spring) that
```
CMake Warning (dev) at CMakeLists.txt:20 (FIND_PACKAGE):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.
```
(this is actually shown in yellow as a full on warning). Go ahead and set CMP0167 to NEW to silence this warning: hopefully if you're using cmake 3.30+ you are using boost 1.70+. Just enabling this single policy felt lower risk than something like `cmake_minimum_required( VERSION 3.12...3.30 )` which would have also made CMP0167 NEW but a lot of other policies NEW too.