### PR TITLE
bump cmake minimum to 3.12 as needed for c++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Defines ChainBase library target.
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.12 )
 project( ChainBase )
 
 #list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules" )


### PR DESCRIPTION
chainbase already requires C++20, so require the first version of cmake that supports C++20. Resolves a warning from latest version of cmake,
```
CMake Deprecation Warning at libraries/chainbase/CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```