### PR TITLE
use `io_context` instead of `io_service`; fixes build on latest boost

### DIFF
--- a/include/chainbase/pinnable_mapped_file.hpp
+++ b/include/chainbase/pinnable_mapped_file.hpp
@@ -3,7 +3,7 @@
 #include <system_error>
 #include <boost/interprocess/managed_mapped_file.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/container/flat_map.hpp>
 #include <filesystem>
 #include <vector>
@@ -85,7 +85,7 @@ class pinnable_mapped_file {
 
    private:
       void                                          set_mapped_file_db_dirty(bool);
-      void                                          load_database_file(boost::asio::io_service& sig_ios);
+      void                                          load_database_file(boost::asio::io_context& sig_ios);
       void                                          save_database_file(bool flush = true);
       static bool                                   all_zeros(const std::byte* data, size_t sz);
       void                                          setup_non_file_mapping();

--- a/src/pinnable_mapped_file.cpp
+++ b/src/pinnable_mapped_file.cpp
@@ -209,7 +209,7 @@ pinnable_mapped_file::pinnable_mapped_file(const std::filesystem::path& dir, boo
       if (on_tempfs_filesystem(_data_file_path))
          BOOST_THROW_EXCEPTION(std::system_error(make_error_code(db_error_code::tempfs_incompatible_mode)));
 
-      boost::asio::io_service sig_ios;
+      boost::asio::io_context sig_ios;
       boost::asio::signal_set sig_set(sig_ios, SIGINT, SIGTERM);
 #ifdef SIGPIPE
       sig_set.add(SIGPIPE);
@@ -358,7 +358,7 @@ void pinnable_mapped_file::setup_non_file_mapping() {
 #endif
 }
 
-void pinnable_mapped_file::load_database_file(boost::asio::io_service& sig_ios) {
+void pinnable_mapped_file::load_database_file(boost::asio::io_context& sig_ios) {
    std::cerr << "CHAINBASE: Preloading \"" << _database_name << "\" database file, this could take a moment..." << '\n';
    char* const dst = (char*)_non_file_mapped_mapping;
    size_t offset = 0;


### PR DESCRIPTION
The macos builds in CI are failing (https://github.com/AntelopeIO/chainbase/actions/runs/12678908028/job/35337503662) because it has the latest boost that removed `io_service` (which has been deprecated since way back). We can just replace this with `io_context`